### PR TITLE
removed firebase react-native since according to its docs, it is depr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Components and native modules. For more search [React Parts](http://react.parts/
 
 - [apsl-react-native-button](https://github.com/APSL/react-native-button) - React Native button component with rounded corners.
 - [autoresponsive-react-native](https://github.com/xudafeng/autoresponsive-react-native) - A Magical Layout Library For React
-- [firebase-react-native](https://github.com/sjmueller/firebase-react-native) - firebase client api hacked to get working with react-native
 - [gl-react-native](https://github.com/ProjectSeptemberInc/gl-react-native) - use OpenGL for performant effects on images and videos
 - [k-react-native-swipe-unlocker](https://github.com/leowang721/k-react-native-swipe-unlocker) - A simple swipe unlock for React Native
 - [markdown-react-native](https://github.com/lwansbrough/react-native-markdown) - A Markdown Component For React Native


### PR DESCRIPTION
…ecated

In the docs it says:

This library is now deprecated!

As of v2.2.7, firebase now has great support for react-native. I highly recommend using the official library instead: