### PR TITLE
Fix broken link for latest react-native release on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,4 +613,4 @@ Assortment of conference and training videos.
 
 - [Release Process](http://facebook.github.io/react/blog/2015/05/22/react-native-release-process.html)
 - [Stable: 0.20](https://github.com/facebook/react-native/releases/tag/v0.20.0)
-- [Next: latest](https://github.com/facebook/react-native/releases/tag/latest)
+- [Next: latest](https://github.com/facebook/react-native/releases/latest)


### PR DESCRIPTION
Link to the latest release on Facebook's React Native Github page was broken.

Now fixed.