### PR TITLE
Add react-router-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [react-native-yynavigator ★0](https://github.com/yiyangest/react-native-yynavigator) - custom navigation bar for react-native
 - [react-native-message-bar ★65](https://github.com/KBLNY/react-native-message-bar) - A module for presenting notifications via an animated message bar at the top/bottom of the screen, highly customizable, for React Native (Android and iOS) projects.
 - [react-native-sglistview ★220](https://github.com/sghiassy/react-native-sglistview) - A memory minded implementation of React Native's ListView
+- [react-router-native ★59](https://github.com/jmurzy/react-router-native) - A routing library for React Native that strives for sensible API parity with [React Router](https://github.com/reactjs/react-router)
 
 
 ### Text & Rich Content


### PR DESCRIPTION
react-router-native [[npm]](https://www.npmjs.com/package/react-router-native)

From the README:

> React Router community decided that a [reducer-based paradigm](https://github.com/reactjs/react-router/issues/743) similar to that of **NavigationExperimental** is better suited to native navigation. Transition to a reducer-based paradigm is also being [discussed](https://github.com/reactjs/react-router/issues/3190) for the web. On the other hand, NavigationExperimental [has no intention to support ](https://github.com/ericvicenti/navigation-rfc/issues/64#issuecomment-209001717) a React Router-like interface and leaves the navigation state up to the developer to maintain.
> 
> A declarative API removes the need to write [boilerplate code](https://github.com/facebook/react-native/commit/1dc33b5f23640a60682ac879b9a3e94a4aa519d9) and speeds up development. React Router Native follows React's __Learn Once, Write Anywhere__ principle by providing a superset of React Router's API that marries _React Router_ to _NavigationExperimental_.

Thanks!

🍺 