### PR TITLE
Add link to test driving react native applications tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ Walkthroughs and tutorials that help you learn React Native.
 - [React Native Express](http://www.reactnativeexpress.com/)
 - [A Mini-Course on React Native Flexbox](https://medium.com/@yoniweisbrod/a-mini-course-on-react-native-flexbox-2832a1ccc6)
 - [React Native with Django backend ★1](https://github.com/shunpochang/connect_love_mobile_demo)
+- [Test driving react native applications](http://www.multunus.com/blog/2016/07/test-driving-react-native-applications/)
 
 ## Problem & Solution
 


### PR DESCRIPTION
We wrote a hands-on tutorial on test driving react native apps. We believe it goes well with rest of the content in this repo.