### PR TITLE
Improves travis build process and validator accuracy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'nokogiri'
 gem 'parallel'
 gem 'kramdown'
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,7 @@ GEM
       multi_xml (>= 0.5.2)
     json (1.8.3)
     kramdown (1.8.0)
-    mini_portile (0.6.2)
     multi_xml (0.5.5)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
     parallel (1.6.1)
 
 PLATFORMS
@@ -18,8 +15,7 @@ PLATFORMS
 DEPENDENCIES
   httparty
   kramdown
-  nokogiri
   parallel
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/validate.rb
+++ b/validate.rb
@@ -1,29 +1,37 @@
 require 'parallel'
-require 'nokogiri'
 require 'open-uri'
-require 'httparty'
+require 'net/http'
+require 'rexml/document'
 require 'kramdown'
+require 'httparty'
 
 def check_link(uri)
-  code = HTTParty.head(uri, :follow_redirects => false).code
-  return code >= 200 && code < 400
+  HTTParty.head(uri).code.to_i.tap do |status|
+    raise "Request had status #{status}" if (400..422).include?(status)
+  end
 end
 
 BASE_URI = ENV['BASE_URI'] || 'https://github.com/jondot/awesome-react-native'
 
-doc = Nokogiri::HTML(Kramdown::Document.new(open('README.md').read).to_html)
-links = doc.css('a').to_a
-puts "Validating #{links.count} links..."
+html_readme = "<html>#{Kramdown::Document.new(open('README.md').read).to_html}</html>"
+readme_doctree = REXML::Document.new(html_readme)
+links = REXML::XPath.match(readme_doctree, '//a')
+
+puts "Validating #{links.size} links..."
 
 invalids = []
-Parallel.each(links, :in_threads => 4) do |link|
+Parallel.each(links, in_threads: 4) do |link|
+  href = link.attribute('href').to_s
   begin
-    uri = URI.join(BASE_URI, link.attr('href'))
-    check_link(uri)
-    putc('.')
-  rescue
+    case check_link(URI.join(BASE_URI, href))
+    when (200...300)
+      putc('.')
+    when (300..302)
+      putc('w')
+    end
+  rescue => e
     putc('F')
-    invalids << "#{link} (reason: #{$!})"
+    invalids << "#{href} (reason: #{e.message})"
   end
 end
 
@@ -36,4 +44,4 @@ unless invalids.empty?
   exit(1)
 end
 
-puts "\nDone."
+# puts "\nDone."


### PR DESCRIPTION
### Actions Taken

* Removes `nokogiri` from build and replaces it with a stdlib `REXML` implementation
* Fixes http status of link validator not affecting results

### Results

`dedup.rb` runs in about the same time, but without `nokogiri` installation time

```
# OLD #

ambp:awesome-react-native andrew$ time bundle exec ruby dedup.rb
Deduping 652 links...

Done.

real  0m0.738s
user  0m0.663s
sys   0m0.071s

# NEW #

ambp:awesome-react-native andrew$ time bundle exec ruby dedupv2.rb
Deduping 652 links...

Done.

real  0m0.875s
user  0m0.798s
sys   0m0.073s
```

`validate.rb` now properly flags links that return a 4xx status code, also no more `nokogiri`

```
# OLD #

ambp:awesome-react-native andrew$ time bundle exec ruby validate.rb
Validating 652 links...
......................................................................................................................................................................................................................
............................................................................................................................................................................................................................................................................................................................................................................................................................................
..........
Done.

real  0m27.421s
user  0m10.627s
sys   0m0.798s

# NEW #

ambp:awesome-react-native andrew$ time bundle exec ruby validatev2.rb
Validating 652 links...
...............F...................F.................................................F................................................................................................................................
....F...................F...................F..........................................................................................................................F...............................................................................F.........................................................................F.......................................................................F................................
...........

Failed links:
- https://github.com/facebook/react-native/tree/master/Examples/UIExplorer/NavigationExperimental (reason: Request had status 404)
- http://facebook.github.io/react-native/docs/known-issues.html (reason: Request had status 404)
- https://github.com/ModusCreateOrg/react-native-better-mapview (reason: Request had status 404)
- https://github.com/gaoli/react-native-range-selector (reason: Request had status 404)
- https://github.com/vitalets/react-native-extended-selectable/ (reason: Request had status 404)
- https://github.com/ninozhang/react-native-style-sheet (reason: Request had status 404)
- https://github.com/bh5-pods/react-native-gcm (reason: Request had status 404)
- https://github.com/Apercu/react-native-bonjour (reason: Request had status 404)
- http://exp.host/ (reason: HTTP redirects too deep)
- https://www.reddit.com/r/reactnative/comments/30hbg3/enabling_live_reload/ (reason: Request had status 429)
Done with errors.

real  0m32.202s
user  0m12.004s
sys   0m0.826s
```

### Conclusion

Build should now give better insight into which links need to be updated/removed. Also removing `nokogiri` install from each build should improve build time.