### PR TITLE
Add ex-navigation to UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [react-native-card-view ★20](https://github.com/jacklam718/react-native-card-view) - A react native card component
 - [apsl-react-native-button ★240](https://github.com/APSL/react-native-button) - React Native button component with rounded corners.
 - [autoresponsive-react-native ★68](https://github.com/xudafeng/autoresponsive-react-native) - A Magical Layout Library For React
+- [ex-navigation ★361](https://github.com/exponentjs/ex-navigation) - A route-centric, batteries-included navigation library for Exponent and React Native that works seamlessly on Android and iOS.
 - [ex-navigator ★464](https://github.com/exponentjs/ex-navigator) - Route-centric navigation built on top of React Native's Navigator
 - [navbar-native ★1](https://github.com/redbaron76/navbar-native) - A new, fully customizable Navbar component for React-Native
 - [react-native-router-sinux ★ ★1](https://github.com/jbpin/react-native-router-sinux) - React Native Router based on new NavigationExperimental that use Sinux as Flux implementation.


### PR DESCRIPTION
Add link to https://github.com/exponentjs/ex-navigation:
> A route-centric, batteries-included navigation library for Exponent and React Native that works seamlessly on Android and iOS.

Thanks for the awesome project!