### PR TITLE
add ADB-auto-restarter && Fix travis validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 
 Useful React Native tooling.
 
+- [ADB Auto Restarter ★2](https://github.com/mahanhaz/adb-auto-restarter) - Restart ADB service Automatically in case of crashing while debugging app with device
 - [react-native-snippets ★117](https://github.com/Shrugs/react-native-snippets) - A collection of Sublime Text Snippets for react-native
 - [exponent](https://getexponent.com/) - Use React Native without XCode (a previewer app + local server infrastructure)
 - [Ruby React Native (via Opal) ★364](https://github.com/zetachang/opal-native) - Use Ruby for building React Native apps

--- a/README.md
+++ b/README.md
@@ -509,7 +509,6 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [react-native-gcm-android ★132](https://github.com/oney/react-native-gcm-android) - GCM for Android
 - [react-native-geocoder ★93](https://github.com/devfd/react-native-geocoder) - react native geocoding and reverse geocoding
 - [react-native-geolocation-android ★3](https://github.com/lxsameer/react-native-geolocation-android) - Geolocation module for react native android
-- [react-native-geolocation ★1](https://github.com/remobile/react-native-geolocation) - A geolocation for react-native
 - [react-native-heading ★3](https://github.com/yonahforst/react-native-heading) - Get device heading (compass) information on iOS or Android
 - [react-native-ibeacon ★155](https://github.com/geniuxconsulting/react-native-ibeacon) - iBeacon support for React Native. The API is very similar to the CoreLocation Objective-C one with the only major difference that regions are plain JavaScript objects. Beacons don't work in the iOS simulator.
 - [react-native-icloud-sync ★18](https://github.com/chirag04/react-native-icloud-sync) - A react-native wrapper for syncing with icloud

--- a/validate.rb
+++ b/validate.rb
@@ -6,7 +6,7 @@ require 'kramdown'
 require 'httparty'
 
 def check_link(uri)
-  HTTParty.head(uri).code.to_i.tap do |status|
+  HTTParty.head(uri, :verify => false).code.to_i.tap do |status|
     raise "Request had status #{status}" if (400..422).include?(status)
   end
 end


### PR DESCRIPTION
this is a very handy tools for android/React-native developers in case they are having problem with ADB's crashing problem while they are developing/testing/debugging with an actual device like me.
this will save alot of times.