### PR TITLE
Add react-native-gl-model-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 
 ### Animation
 - [react-native-animated-sprite ★3](https://github.com/micahrye/react-native-animated-sprite) - A feature rich declarative component for animation, tweening, and dragging sprites.
+- [react-native-gl-model-view ★62](https://github.com/rastapasta/react-native-gl-model-view) - Display and animate textured Wavefront .OBJ 3D models with 60fps (iOS)
 
 ### Other Platforms
 


### PR DESCRIPTION
Hey team!

I would love to add [react-native-gl-model-view](https://github.com/rastapasta/react-native-gl-model-view) to the list!

Main features:

* Display, rotate, scale and translate any textured 3D object!
* Animate with blasting fast 60FPS by using the [Animated API](https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver) native driver
* Load any Wavefront .OBJ or GLEssentials model
* Use all texture image formats supported by [UIImage](https://developer.apple.com/library/content/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/LoadingImages/LoadingImages.html#//apple_ref/doc/uid/TP40010156-CH17-SW8)