### PR TITLE
Add rn-placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [react-native-zoom-image](https://github.com/Tinysymphony/react-native-zoom-image) - An image viewer component for react-native, like twitter's image viewer.
 - [react-native-hijri-date-picker](https://github.com/Codelabsys/react-native-hijri-date-picker-android) -  Date Picker Dialog for Hijri calendar for android.
 - [react-native-md-motion-buttons](https://github.com/zecaptus/react-native-md-motion-buttons) - Material design motion button inspired by inVision app.
+- [rn-placeholder](https://github.com/Skahrz/rn-placeholder) - Skeleton placeholder loader with (optional) animations
 
 ### Navigation
 - [native-navigation ★1237](https://github.com/airbnb/native-navigation) - Native navigation library for React Native applications


### PR DESCRIPTION
Simple skeleton loader for react native.

It displays lines and shapes on the screen (with optional animations) before state is ready, and then renders the concerned child component.

Example on here : https://github.com/Skahrz/rn-placeholder

EDIT: Example folder added with android and iOS