### PR TITLE
Adds react-native-bundle-visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Useful React Native tooling.
 - [haul ★1029](https://github.com/callstack-io/haul) - command line tool for developing React Native apps
 - [rn-nodeify ★64](https://github.com/mvayngrib/rn-nodeify) - hack to allow react-native projects to use node core modules
 - [Deco IDE](https://www.decosoftware.com/) - React Native IDE with components manager
+- [react-native-bundle-visualizer ★32](https://github.com/IjzerenHein/react-native-bundle-visualizer) - See what's inside your RN bundle; useful for optimizing the bundle size
 - [react-native-debugger ★638](https://github.com/jhen0409/react-native-debugger) - The standalone app for React Native Debugger, with React DevTools / Redux DevTools
 - [react-native-exception-handler](https://github.com/master-atul/react-native-exception-handler) – Avoid silent crash and errors on the production build of your app
 - [generact](http://github.com/diegohaz/generact) - CLI that generates components based on existing ones no matter how you structure your app


### PR DESCRIPTION
Adds a reference to the react-native-bundle-visualizer utility. The bundle visualizer is useful for isolating imported packages that increase your bundle size considerably (and sometimes unexpectedly) (e.g. when importing a big monolithic library)