### PR TITLE
Add react-native-open-maps to UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [react-native-nested-stylesheet ★54](https://github.com/pjjanak/react-native-nested-stylesheets) - Nestable stylesheets for react-native.
 - [react-native-newsticker ★21](https://github.com/moschan/react-native-newsticker) - The News Ticker component for React Native
 - [react-native-nmrangeslider-ios ★19](https://github.com/Enrise/react-native-nmrangeslider-ios) - The NMRangeSlider component for React Native
+- [react-native-open-maps ★19](https://github.com/brh55/react-native-open-maps) - A simple lib to open up the corresponding map application (Google or Apple Maps) from a set of coordinates (latitude & longitude) within react-native
 - [react-native-offline-mode ★55](https://github.com/rauchy/react-native-offline-mode) - Swap your app with an offline version while there's no connectivity
 - [react-native-orientation-controller ★19](https://github.com/inProgress-team/react-native-orientation-controller) - A react-native library for obtaining and controlling the current device and application orientation
 - [react-native-orientation-listener ★117](https://github.com/walmartreact/react-native-orientation-listener) - A react-native library for obtaining current device orientation


### PR DESCRIPTION
Added react-native-open-maps, a simplified lib to handle opening of maps per coordinates, within the UI section.. let me know if you feel it should be moved to tools or geolocation.