### PR TITLE
Add Buttercup mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,7 @@ Open source React Native apps and other examples.
 - [PxView ★42](https://github.com/alphasp/pxview) - An unofficial Pixiv app client for Android and iOS
 - [Todo List ★2](https://github.com/rishabhbhatia/react-native-todo) - Todo-List app using SwipeView with ES6 standards for iOS and Android.
 - [Quick-Sample ★2](https://github.com/innFactory/react-native-quick-sample) - A small and simple example app with navigation, data persistence, redux, listview and animation.
+- [Buttercup Mobile ★41](https://github.com/buttercup/buttercup-mobile) - Mobile password manager
 
 ## Frameworks
 


### PR DESCRIPTION
Adding Buttercup (for mobile) - an open-source password manager (that has an electron desktop counterpart).

Website: [buttercup.pw](https://buttercup.pw)

![photo-2017-10-07-17-36-47_9692](https://user-images.githubusercontent.com/3869469/32931017-a116022c-cb6a-11e7-9a3f-d0dfc4c5da83.PNG)
