### PR TITLE
Added ReactNative Bridge Plugin Library for Android & iOS App Tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,9 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [react-native-submit-button ★64](https://github.com/ronak301/react-native-submit-button) - Animated Submit button. Works on both android and ios.
 - [react-native-3dcube-navigation ★8](https://github.com/zehfernandes/react-native-3dcube-navigation) - Page Swiper component with 3D cube transition (horizontal and vertical)
 - [react-native-switch-selector](https://github.com/App2Sales/react-native-switch-selector) - A custom Switch Selector component for Android and iOS.
+- [react-native-taptargetview](https://github.com/prscX/react-native-taptargetview) - React Native Bridge for Android KeepSafe/TapTargetView. An implementation of tap targets from the Material Design guidelines for feature discovery.
+- [react-native-material-showcase-ios](https://github.com/prscX/react-native-material-showcase-ios) - React Native Bridge for iOS aromajoin/material-showcase-ios. An elegant and beautiful showcase for iOS apps.
+
 
 ### Navigation
 - [native-navigation ★1237](https://github.com/airbnb/native-navigation) - Native navigation library for React Native applications


### PR DESCRIPTION
Hi @jondot 

This is with reference to issue: [546](https://github.com/jondot/awesome-react-native/issues/546). I have created below RN Bridge Plugin Libraries for Android & iOS Platform  App Tour

- [react-native-taptargetview](https://github.com/prscX/react-native-taptargetview)
- [react-native-material-showcase-ios](https://github.com/prscX/react-native-material-showcase-ios)

Hope it might be useful for folks looking for nice, cool library for App Tour on RN

Can you please merge the raised request, please let me know in case any discussion is required for the same

Thanks
Pranav