### PR TITLE
fix(build): skip udemy links validation if they return 403 http status

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Content published on the Web.
 ### Internals
 
 - [Performance](https://facebook.github.io/react-native/docs/performance.html#common-sources-of-performance-problems)
-- [Android Performance](https://facebook.github.io/react-native/docs/android-ui-performance.html)
 - [React Native Debugger Internals](https://medium.com/@shaheenghiassy/deep-diving-react-native-debugging-ea406ed3a691)
 - [Dirty-up and execute top-down](http://blog.vjeux.com/2015/javascript/dirty-up-and-execute-top-down.html) - @vjeux on React's optimizations for background color, layout, and more
 - [Optimizing React Native](https://www.youtube.com/watch?v=0MlT74erp60)
@@ -640,7 +639,6 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 
 
 ### System
-- [react-native-incall-manager ★174](https://github.com/zxcpoiu/react-native-incall-manager) - Handling media-routes/sensors/events during a audio/video chat on React Native
 - [react-native-addressbook ★78](https://github.com/rt2zz/react-native-addressbook) - AddressBook module for react-native
 - [react-native-android-sms-listener ★123](https://github.com/CentaurWarchief/react-native-android-sms-listener) - Allows you to listen for incoming SMS messages
 - [react-native-android-sms ★42](https://github.com/msmakhlouf/react-native-android-sms) - A react native android module to list/send sms.
@@ -1108,7 +1106,7 @@ Assortment of conference and training videos.
 - [Let's build a React Native app in 20 minutes](https://www.youtube.com/watch?v=9ArhJiMGVDc) and [Gist](https://gist.github.com/peterjmag/2ef39ba5d25f3f1e0008)
 - Egghead.io: [React Native Fundamentals](https://egghead.io/series/react-native-fundamentals)
 - Pluralsight.com: [Build iOS Apps with React Native](http://www.pluralsight.com/courses/build-ios-apps-react-native)
-- Udemy.com: [Build apps with React Native](https://www.udemy.com/reactnative/learn/v4/overview)
+- Udemy.com: [Build apps with React Native](https://www.udemy.com/the-complete-react-native-and-redux-course/)
 - [React Native training ★238](https://www.gitbook.com/book/unbug/react-native-training/details)
 - Dailydrip.com: [Learn React Native in 5min per day](https://www.dailydrip.com/topics/react-native/)
 - [Awesome React Native Education ★326](https://github.com/hsavit1/Awesome-React-Native-Education)
@@ -1118,7 +1116,7 @@ Assortment of conference and training videos.
 - [React Native Basics: Build a Currency Converter](http://learn.handlebarlabs.com/p/react-native-basics-build-a-currency-converter?ref=awesome-react-native) - (Free) A multi-hour in-depth video course showing you how to build apps with React Native.
 - [React Native in Arabic: Build a newspaper app](https://www.youtube.com/playlist?list=PLk-CkzAysw4BLLNtATmnZOA8E8I6TP8MS) - (Free) A simple to follow video series in Arabic showing you how to build a newspaper app with React Native.
 - [Build a Weather app ](https://cloneable.io/courses/enrolled/103341) - (Free) A course to build a weather app with React Native.
-- Udemy.com: [Automate Your React Native Releases with Fastlane & Bitrise](https://www.udemy.com/automate-your-react-native-releases-with-fastlane-and-bitrise/?couponCode=AWESOME-REACT-NATIVE&utm_source=gh_arn&utm_medium=link) - Learn step-by-step how to release your React Native applications into Stores automatically by using Fastlane & Bitrise.
+- Udemy.com: [Automate Your React Native Releases with Fastlane & Bitrise](https://www.udemy.com/automate-your-react-native-releases-with-fastlane-and-bitrise/?couponCode=AWESOME-REACT-NATIVE) - Learn step-by-step how to release your React Native applications into Stores automatically by using Fastlane & Bitrise.
 
 
 ## Blogs

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Content published on the Web.
 
 ### Reference
 
-- [React Native Styling Cheatsheet ★555](https://github.com/vhpoet/react-native-styling-cheat-sheet)
+- [React Native Styling Cheatsheet ★1468](https://github.com/vhpoet/react-native-styling-cheat-sheet)
 
 ### Howtos
 
@@ -153,362 +153,362 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 
 ### UI
 
-- [react-native-paper★109](https://github.com/callstack/react-native-paper.git) Material Design for React Native (Android & iOS).
-- [react-virgin★934](https://github.com/Trixieapp/react-virgin) The react-native UI Kit you've been looking for.
-- [rn-render-perfs★10](https://github.com/mfrachet/rn-render-perfs) - Measure React rendering lifecycles using UI controls
-- [react-native-toast-native★10](https://github.com/onemolegames/react-native-toast-native) React Native Toast component for both Android and iOS.
-- [rn-ab-hoc★13](https://github.com/mfrachet/rn-ab-hoc) - Poor intrusive way to make A/B Testing by using an HoC instead of components.
-- [rn-placeholder★252](https://github.com/mfrachet/rn-placeholder) - Display some placeholder stuff before rendering your text or media content in React Native (+ React Native Web !)
-- [react-native-scrollview-smart★41](https://github.com/bolket/react-native-scrollview-smart) - A Smart ScrollView component for IOS and Android.
-- [react-native-fast-image★265](https://github.com/DylanVann/react-native-fast-image) - FastImage, performant React Native image component.
-- [photo-viewer★27](https://github.com/merryjs/photo-viewer) - A photo viewer for react native build on top of NYTPhotoViewer and FrescoImageViewer.
-- [react-native-pagination ★5](https://github.com/garrettmac/react-native-pagination) - A Beautiful Pagination Plugin For Lists.
-- [react-native-search-box★87](https://github.com/crabstudio/react-native-search-box) - A simple search box with animation, inspired from ios search bar.
-- [rn-sliding-up-panel ★22](https://github.com/octopitus/rn-sliding-up-panel) - React Native draggable sliding up panel purly implemented in Javascript. Works nicely on both iOS and Android.
-- [react-native-splash-screen ★383](https://github.com/crazycodeboy/react-native-splash-screen) - A splash screen for react-native, hide when application loaded ,it works on iOS and Android.
-- [react-native-display ★23](https://github.com/sundayhd/react-native-display) - This module brings "Display: none" (css style) to turn on/off components from render. Using this module will improve your app performance and appearance with the enter/exit animations.
-- [react-native-check-box ★65](https://github.com/crazycodeboy/react-native-check-box) - Checkbox component for react native, it works on iOS and Android.
-- [react-native-easy-toast ★69](https://github.com/crazycodeboy/react-native-easy-toast) - A react native module to show toast like android, it works on iOS and Android.
-- [react-native-button-component ★165](https://github.com/jacklam718/react-native-button-component) - A Beautiful, Customizable React Native Button component for iOS & Android
-- [react-native-popup-dialog ★203](https://github.com/jacklam718/react-native-popup-dialog) - A React Native Popup Dialog Easy Use & Support Use Custom Animation. For IOS & Android
-- [react-native-card-media ★2](https://github.com/dondoko-susumu/react-native-card-media) - Card media component & Support multiple image layout
-- [react-native-card-view ★54](https://github.com/jacklam718/react-native-card-view) - A react native card component
-- [apsl-react-native-button ★372](https://github.com/APSL/react-native-button) - React Native button component with rounded corners.
-- [autoresponsive-react-native ★99](https://github.com/xudafeng/autoresponsive-react-native) - A Magical Layout Library For React
-- [react-native-mobx ★138](https://github.com/aksonov/react-native-mobx) - Make your app reactive with MobX and react-native-router-flux
-- [gl-react-native ★1135](https://github.com/ProjectSeptemberInc/gl-react-native) - use OpenGL for performant effects on images and videos
-- [k-react-native-swipe-unlocker ★30](https://github.com/leowang721/k-react-native-swipe-unlocker) - A simple swipe unlock for React Native
-- [react-native-progress ★593](https://github.com/oblador/react-native-progress) - Progress indicators and spinners for React Native using ReactART.
-- [react-native-accordion ★236](https://github.com/naoufal/react-native-accordion) - An Accordion Component for React Native
-- [react-native-action-button ★722](https://github.com/mastermoo/react-native-action-button) - A customizable Float Button Component for React Native
-- [react-native-custom-actionsheet](https://github.com/valerybugakov/react-native-custom-actionsheet) - Fully customizable ActionSheet for React Native.
-- [react-native-actionsheet-native ★11](https://github.com/slowpath/react-native-actionsheet) - Android ActionSheet support for React Native
-- [react-native-activity-view ★297](https://github.com/naoufal/react-native-activity-view) - iOS share and action sheets for React Native
-- [react-native-adbannerview ★40](https://github.com/Purii/react-native-adbannerview) - React Native Bridge for ADBannerView
-- [react-native-air-progress-bar ★2](https://github.com/kis/react-native-air-progress-bar) - React Native progress-bar component, customizable and animated
-- [react-native-alphabetlistview ★151](https://github.com/sunnylqm/react-native-alphabetlistview) - A ListView with a sidebar to jump to sections directly, based on johanneslumpe's react-native-selectablesectionlistview
-- [react-native-android-blurryoverlay ★48](https://github.com/kwaak/react-native-android-blurryoverlay) - A react native android package to show a blurry overlay.
-- [react-native-android-circles ★14](https://github.com/kwaak/react-native-android-circles) - A react native android package to show a circle progress view.
-- [react-native-android-iconify ★31](https://github.com/lwhiteley/react-native-android-iconify) - icons for react native android using android-iconify
-- [react-native-android-kit ★75](https://github.com/ayoubdev/react-native-android-kit) - A set of native Android UI components and modules for React Native framework (Android Design Support Library, TabLayout, Floating Action Button and more...).
-- [react-native-android-statusbar ★110](https://github.com/NishanthShankar/react-native-android-statusbar) - A react native android package to control the status bar.
-- [react-native-animated-check-mark ★11](https://github.com/AppliKeySolutions/RocketButton) - A small react component for animated cross-mark transformation.
-- [react-native-animated-styles ★1](https://github.com/ericpkerr/react-native-animated-styles) - Easily animate/transition react components between two style states.
-- [react-native-app-intro ★886](https://github.com/FuYaoDe/react-native-app-intro) - A React Native parallax effect app intro
-- [react-native-app-intro-v2 *5](https://github.com/Sh1n1x/react-native-app-intro) - Latest App intro
-- [react-native-awesome-button ★141](https://github.com/larsvinter/react-native-awesome-button) - A React Native component rendering a button supporting showing different appearances and functionality given the passed props
-- [react-native-awesome-alert ★5](https://github.com/heyman333/react-native-awesome-alert) - Modal component that offers awesome options and costomizable view in React Native
-- [react-native-auto-typing-text ★11](https://github.com/phuongla/react-native-auto-typing-text) - An auto typing text component for react-native
-- [react-native-autolink ★77](https://github.com/joshswan/react-native-autolink) - Autolinking component for React Native
-- [react-native-autocomplete ★111](https://github.com/nulrich/RCTAutoComplete) - React Native Component for MLPAutoCompleteTextField
-- [react-native-autocomplete-input ★104](https://github.com/l-urence/react-native-autocomplete-input) - Pure javascript autocomplete input for react-native
-- [react-native-avatar-gravatar ★10](https://github.com/niborb/react-native-gravatar) - React Native Gravatar component
-- [react-native-bar-collapsible ★11](https://github.com/caroaguilar/react-native-bar-collapsible) - A Bar component that can be collapsible (toggle/accordion), clickable or text-only.
-- [react-native-beautiful-video-recorder ★27](https://github.com/phuochau/react-native-beautiful-video-recorder) - The video recorder component that extends from react-native-camera. It works for both iOS & Android.
-- [react-native-beautiful-image ★12](https://github.com/phuochau/react-native-beautiful-image) - The Beautiful Image component that supports fadeIn animation and shows placeholderSource if the main source can't be loaded.
-- [react-native-big-slider](https://github.com/netbeast/react-native-big-slider) - Yet another, big one, pure JS easily customisable and hackable react-native slider component.
-- [react-native-blur ★1021](https://github.com/Kureev/react-native-blur) - React Native Blur component
-- [react-native-bouncy-drawer ★2](https://github.com/SoftZen/react-native-bouncy-drawer) - Highly customizable Bouncy Drawer
-- [react-native-fxblurview ★26](https://github.com/magus/react-native-fxblurview) - React Native wrapper for popular FXBlurView library for realtime, fine-tuned blur effects
-- [react-native-button ★521](https://github.com/ide/react-native-button)
-- [react-native-bottom-sheet-behavior ★404](https://github.com/cesardeazevedo/react-native-bottom-sheet-behavior) - A react native wrapper for android BottomSheetBehavior.
-- [react-native-cache-image ★115](https://github.com/remobile/react-native-cache-image) - A cache-image for react-native
-- [react-native-cacheable-image ★120](https://github.com/jayesbe/react-native-cacheable-image) - A filesystem cacheable image component for react-native
-- [react-native-calendars ★1115](https://github.com/wix/react-native-calendars) - React Native Calendar Components 📆
-- [react-native-calendar-android ★39](https://github.com/chymtt/ReactNativeCalendarAndroid) - A simple material-themed calendar for react native android
-- [react-native-calendar-datepicker ★30](https://github.com/vlad-doru/react-native-calendar-datepicker) - A cross-platform calendar datepicker
-- [react-native-calendar-select ★1](https://github.com/Tinysymphony/react-native-calendar-select) - A component to select a date period from calendar modal, like Airbnb.
-- [react-native-calendar ★339](https://github.com/christopherdro/react-native-calendar) - Calendar Component for React Native
-- [react-native-canvas ★109](https://github.com/lwansbrough/react-native-canvas) - A Canvas element for React Native
-- [react-native-cardview ★20](https://github.com/Kishanjvaghela/react-native-cardview) - CardView for react-native (All Android version and iOS)
-- [react-native-carousel ★302](https://github.com/nick/react-native-carousel) - Simple carousel component for react-native
-- [react-native-carousel-control ★110](https://github.com/machadogj/react-native-carousel-control) - React Native Carousel control with support for iOS and Android.
-- [react-native-cell-components ★1](https://github.com/lodev09/react-native-cell-components) - Awesome react-native cell components! From a Cell to more complex & awesome components.
-- [react-native-censored](https://github.com/redpandatronicsuk/react-native-censored) - React Native component to censor content.
-- [react-native-chart ★825](https://github.com/onefold/react-native-chart) - react-native-chart is a simple module for adding line charts, area charts, or bar charts to your React Native app.
-- [react-native-charts ★58](https://github.com/PrazAs/react-native-charts) - Delightfully-animated data visualization.
-- [react-native-checkbox ★74](https://github.com/sconxu/react-native-checkbox) - Checkbox component for React native
-- [react-native-circle-checkbox ★15](https://github.com/ParamoshkinAndrew/ReactNativeCircleCheckbox) - Circle checkbox component for React Native
+- [react-native-paper ★109](https://github.com/callstack/react-native-paper.git) Material Design for React Native (Android & iOS).
+- [react-virgin ★1108](https://github.com/Trixieapp/react-virgin) The react-native UI Kit you've been looking for.
+- [rn-render-perfs ★25](https://github.com/mfrachet/rn-render-perfs) - Measure React rendering lifecycles using UI controls
+- [react-native-toast-native ★21](https://github.com/onemolegames/react-native-toast-native) React Native Toast component for both Android and iOS.
+- [rn-ab-hoc ★17](https://github.com/mfrachet/rn-ab-hoc) - Poor intrusive way to make A/B Testing by using an HoC instead of components.
+- [rn-placeholder ★314](https://github.com/mfrachet/rn-placeholder) - Display some placeholder stuff before rendering your text or media content in React Native (+ React Native Web !)
+- [react-native-scrollview-smart ★49](https://github.com/bolket/react-native-scrollview-smart) - A Smart ScrollView component for IOS and Android.
+- [react-native-fast-image ★641](https://github.com/DylanVann/react-native-fast-image) - FastImage, performant React Native image component.
+- [photo-viewer ★32](https://github.com/merryjs/photo-viewer) - A photo viewer for react native build on top of NYTPhotoViewer and FrescoImageViewer.
+- [react-native-pagination ★85](https://github.com/garrettmac/react-native-pagination) - A Beautiful Pagination Plugin For Lists.
+- [react-native-search-box ★183](https://github.com/crabstudio/react-native-search-box) - A simple search box with animation, inspired from ios search bar.
+- [rn-sliding-up-panel ★118](https://github.com/octopitus/rn-sliding-up-panel) - React Native draggable sliding up panel purly implemented in Javascript. Works nicely on both iOS and Android.
+- [react-native-splash-screen ★1311](https://github.com/crazycodeboy/react-native-splash-screen) - A splash screen for react-native, hide when application loaded ,it works on iOS and Android.
+- [react-native-display ★103](https://github.com/sundayhd/react-native-display) - This module brings "Display: none" (css style) to turn on/off components from render. Using this module will improve your app performance and appearance with the enter/exit animations.
+- [react-native-check-box ★205](https://github.com/crazycodeboy/react-native-check-box) - Checkbox component for react native, it works on iOS and Android.
+- [react-native-easy-toast ★307](https://github.com/crazycodeboy/react-native-easy-toast) - A react native module to show toast like android, it works on iOS and Android.
+- [react-native-button-component ★342](https://github.com/jacklam718/react-native-button-component) - A Beautiful, Customizable React Native Button component for iOS & Android
+- [react-native-popup-dialog ★591](https://github.com/jacklam718/react-native-popup-dialog) - A React Native Popup Dialog Easy Use & Support Use Custom Animation. For IOS & Android
+- [react-native-card-media ★37](https://github.com/dondoko-susumu/react-native-card-media) - Card media component & Support multiple image layout
+- [react-native-card-view ★95](https://github.com/jacklam718/react-native-card-view) - A react native card component
+- [apsl-react-native-button ★538](https://github.com/APSL/react-native-button) - React Native button component with rounded corners.
+- [autoresponsive-react-native ★146](https://github.com/xudafeng/autoresponsive-react-native) - A Magical Layout Library For React
+- [react-native-mobx ★203](https://github.com/aksonov/react-native-mobx) - Make your app reactive with MobX and react-native-router-flux
+- [gl-react-native ★1501](https://github.com/ProjectSeptemberInc/gl-react-native) - use OpenGL for performant effects on images and videos
+- [k-react-native-swipe-unlocker ★48](https://github.com/leowang721/k-react-native-swipe-unlocker) - A simple swipe unlock for React Native
+- [react-native-progress ★1260](https://github.com/oblador/react-native-progress) - Progress indicators and spinners for React Native using ReactART.
+- [react-native-accordion ★321](https://github.com/naoufal/react-native-accordion) - An Accordion Component for React Native
+- [react-native-action-button ★1269](https://github.com/mastermoo/react-native-action-button) - A customizable Float Button Component for React Native
+- [react-native-custom-actionsheet ★3](https://github.com/valerybugakov/react-native-custom-actionsheet) - Fully customizable ActionSheet for React Native.
+- [react-native-actionsheet-native ★21](https://github.com/slowpath/react-native-actionsheet) - Android ActionSheet support for React Native
+- [react-native-activity-view ★361](https://github.com/naoufal/react-native-activity-view) - iOS share and action sheets for React Native
+- [react-native-adbannerview ★47](https://github.com/Purii/react-native-adbannerview) - React Native Bridge for ADBannerView
+- [react-native-air-progress-bar ★28](https://github.com/kis/react-native-air-progress-bar) - React Native progress-bar component, customizable and animated
+- [react-native-alphabetlistview ★270](https://github.com/sunnylqm/react-native-alphabetlistview) - A ListView with a sidebar to jump to sections directly, based on johanneslumpe's react-native-selectablesectionlistview
+- [react-native-android-blurryoverlay ★68](https://github.com/kwaak/react-native-android-blurryoverlay) - A react native android package to show a blurry overlay.
+- [react-native-android-circles ★15](https://github.com/kwaak/react-native-android-circles) - A react native android package to show a circle progress view.
+- [react-native-android-iconify ★30](https://github.com/lwhiteley/react-native-android-iconify) - icons for react native android using android-iconify
+- [react-native-android-kit ★93](https://github.com/ayoubdev/react-native-android-kit) - A set of native Android UI components and modules for React Native framework (Android Design Support Library, TabLayout, Floating Action Button and more...).
+- [react-native-android-statusbar ★122](https://github.com/NishanthShankar/react-native-android-statusbar) - A react native android package to control the status bar.
+- [react-native-animated-check-mark ★24](https://github.com/AppliKeySolutions/RocketButton) - A small react component for animated cross-mark transformation.
+- [react-native-animated-styles ★2](https://github.com/ericpkerr/react-native-animated-styles) - Easily animate/transition react components between two style states.
+- [react-native-app-intro ★1680](https://github.com/FuYaoDe/react-native-app-intro) - A React Native parallax effect app intro
+- [react-native-app-intro-v2 *5 ★10](https://github.com/Sh1n1x/react-native-app-intro) - Latest App intro
+- [react-native-awesome-button ★192](https://github.com/larsvinter/react-native-awesome-button) - A React Native component rendering a button supporting showing different appearances and functionality given the passed props
+- [react-native-awesome-alert ★17](https://github.com/heyman333/react-native-awesome-alert) - Modal component that offers awesome options and costomizable view in React Native
+- [react-native-auto-typing-text ★29](https://github.com/phuongla/react-native-auto-typing-text) - An auto typing text component for react-native
+- [react-native-autolink ★145](https://github.com/joshswan/react-native-autolink) - Autolinking component for React Native
+- [react-native-autocomplete ★139](https://github.com/nulrich/RCTAutoComplete) - React Native Component for MLPAutoCompleteTextField
+- [react-native-autocomplete-input ★210](https://github.com/l-urence/react-native-autocomplete-input) - Pure javascript autocomplete input for react-native
+- [react-native-avatar-gravatar ★13](https://github.com/niborb/react-native-gravatar) - React Native Gravatar component
+- [react-native-bar-collapsible ★27](https://github.com/caroaguilar/react-native-bar-collapsible) - A Bar component that can be collapsible (toggle/accordion), clickable or text-only.
+- [react-native-beautiful-video-recorder ★59](https://github.com/phuochau/react-native-beautiful-video-recorder) - The video recorder component that extends from react-native-camera. It works for both iOS & Android.
+- [react-native-beautiful-image ★40](https://github.com/phuochau/react-native-beautiful-image) - The Beautiful Image component that supports fadeIn animation and shows placeholderSource if the main source can't be loaded.
+- [react-native-big-slider ★11](https://github.com/netbeast/react-native-big-slider) - Yet another, big one, pure JS easily customisable and hackable react-native slider component.
+- [react-native-blur ★1644](https://github.com/Kureev/react-native-blur) - React Native Blur component
+- [react-native-bouncy-drawer ★62](https://github.com/SoftZen/react-native-bouncy-drawer) - Highly customizable Bouncy Drawer
+- [react-native-fxblurview ★44](https://github.com/magus/react-native-fxblurview) - React Native wrapper for popular FXBlurView library for realtime, fine-tuned blur effects
+- [react-native-button ★647](https://github.com/ide/react-native-button)
+- [react-native-bottom-sheet-behavior ★500](https://github.com/cesardeazevedo/react-native-bottom-sheet-behavior) - A react native wrapper for android BottomSheetBehavior.
+- [react-native-cache-image ★151](https://github.com/remobile/react-native-cache-image) - A cache-image for react-native
+- [react-native-cacheable-image ★219](https://github.com/jayesbe/react-native-cacheable-image) - A filesystem cacheable image component for react-native
+- [react-native-calendars ★1625](https://github.com/wix/react-native-calendars) - React Native Calendar Components 📆
+- [react-native-calendar-android ★44](https://github.com/chymtt/ReactNativeCalendarAndroid) - A simple material-themed calendar for react native android
+- [react-native-calendar-datepicker ★58](https://github.com/vlad-doru/react-native-calendar-datepicker) - A cross-platform calendar datepicker
+- [react-native-calendar-select ★60](https://github.com/Tinysymphony/react-native-calendar-select) - A component to select a date period from calendar modal, like Airbnb.
+- [react-native-calendar ★539](https://github.com/christopherdro/react-native-calendar) - Calendar Component for React Native
+- [react-native-canvas ★214](https://github.com/lwansbrough/react-native-canvas) - A Canvas element for React Native
+- [react-native-cardview ★132](https://github.com/Kishanjvaghela/react-native-cardview) - CardView for react-native (All Android version and iOS)
+- [react-native-carousel ★370](https://github.com/nick/react-native-carousel) - Simple carousel component for react-native
+- [react-native-carousel-control ★162](https://github.com/machadogj/react-native-carousel-control) - React Native Carousel control with support for iOS and Android.
+- [react-native-cell-components ★78](https://github.com/lodev09/react-native-cell-components) - Awesome react-native cell components! From a Cell to more complex & awesome components.
+- [react-native-censored ★2](https://github.com/redpandatronicsuk/react-native-censored) - React Native component to censor content.
+- [react-native-chart ★1208](https://github.com/onefold/react-native-chart) - react-native-chart is a simple module for adding line charts, area charts, or bar charts to your React Native app.
+- [react-native-charts ★64](https://github.com/PrazAs/react-native-charts) - Delightfully-animated data visualization.
+- [react-native-checkbox ★122](https://github.com/sconxu/react-native-checkbox) - Checkbox component for React native
+- [react-native-circle-checkbox ★26](https://github.com/ParamoshkinAndrew/ReactNativeCircleCheckbox) - Circle checkbox component for React Native
 - [react-native-circle-progress ★23](https://github.com/guodong000/react-native-circle-progress) - A custom Circle Progress Indicator for React Native
 - [react-native-circle-view ★32](https://github.com/nucleartux/react-native-circle-view) - circle progress for react native android using CircleView
-- [react-native-circular-action-menu ★66](https://github.com/geremih/react-native-circular-action-menu) - An animated and customizable circular floating menu.
-- [react-native-circular-progress ★414](https://github.com/bgryszko/react-native-circular-progress) - React Native component for creating animated, circular progress with ReactART
-- [react-native-collapsible ★365](https://github.com/oblador/react-native-collapsible) - Animated collapsible component for React Native using the new Animated API with fallback. Good for accordions, toggles etc
-- [react-native-collapsing-toolbar ★44](https://github.com/cesardeazevedo/react-native-collapsing-toolbar) - wrapper for android CollapsingToolbarLayout
-- [react-native-compress ★4](https://github.com/phuochau/react-native-compress) - Compress video for react native. Only for iOS, Android will be coming.
-- [react-native-color-wheel](https://github.com/netbeast/react-native-color-wheel) - A react native reusable color picker wheel
-- [react-native-countdown ★17](https://github.com/buhe/react-native-countdown) - react native countdown button
-- [react-native-country-picker ★5](https://github.com/tofugear/react-native-country-picker) - React Native Country Picker
-- [react-native-country-picker-modal ★136](https://github.com/xcarpentier/react-native-country-picker-modal) - Country picker provides a modal allowing a user to select a country from a list. It display a flag next to each country name.
+- [react-native-circular-action-menu ★216](https://github.com/geremih/react-native-circular-action-menu) - An animated and customizable circular floating menu.
+- [react-native-circular-progress ★733](https://github.com/bgryszko/react-native-circular-progress) - React Native component for creating animated, circular progress with ReactART
+- [react-native-collapsible ★690](https://github.com/oblador/react-native-collapsible) - Animated collapsible component for React Native using the new Animated API with fallback. Good for accordions, toggles etc
+- [react-native-collapsing-toolbar ★108](https://github.com/cesardeazevedo/react-native-collapsing-toolbar) - wrapper for android CollapsingToolbarLayout
+- [react-native-compress ★9](https://github.com/phuochau/react-native-compress) - Compress video for react native. Only for iOS, Android will be coming.
+- [react-native-color-wheel ★31](https://github.com/netbeast/react-native-color-wheel) - A react native reusable color picker wheel
+- [react-native-countdown ★25](https://github.com/buhe/react-native-countdown) - react native countdown button
+- [react-native-country-picker ★7](https://github.com/tofugear/react-native-country-picker) - React Native Country Picker
+- [react-native-country-picker-modal ★246](https://github.com/xcarpentier/react-native-country-picker-modal) - Country picker provides a modal allowing a user to select a country from a list. It display a flag next to each country name.
 - [react-native-create-new-file-ios ★1](https://github.com/rhaker/react-native-create-new-file-ios) - A react-native interface for creating a blank new file on ios. File must not already exist.
-- [react-native-credit-card-input ★265](https://github.com/sbycrosz/react-native-credit-card-input) - 💳 💳 Easy (and good looking) credit-card input for your React Native Project
-- [react-native-custom-actsheet ★32](https://github.com/guodong000/react-native-custom-actsheet) - A custom ActionSheet for react-native
-- [react-native-multi-select ★12](https://github.com/hasangilak/react-native-multi-select) - you know select2 on web ? now you have it in react native at your command :)
-- [react-native-custom-checkbox ★7](https://github.com/caroaguilar/react-native-custom-checkbox) - React Native checkbox that can be customize. Works for both Android and iOS.
-- [react-native-dashed-border ★23](https://github.com/chirag04/react-native-dashed-border) - A  element for react-native
-- [react-native-date ★42](https://github.com/nucleartux/react-native-date) - React Native date and time pickers for Android
-- [react-native-timepicker ★11](https://github.com/milasevicius/react-native-timepicker) - React Native timepicker for iOS
-- [react-native-datepicker ★306](https://github.com/xgfe/react-native-datepicker) - React Native date, datetime and time picker for both Android and IOS
-- [react-native-device-display ★85](https://github.com/kkjdaniel/react-native-display-view) - A simple way to create dynamic views through device and display detection, allowing the creation of adaptable and universal apps.
-- [react-native-dial ★12](https://github.com/netbeast/react-native-dial) - A react native reusable and efficient dial knob element.
-- [react-native-dialogs ★273](https://github.com/aakashns/react-native-dialogs) - React Native wrappers for https://github.com/afollestad/material-dialogs
+- [react-native-credit-card-input ★480](https://github.com/sbycrosz/react-native-credit-card-input) - 💳 💳 Easy (and good looking) credit-card input for your React Native Project
+- [react-native-custom-actsheet ★39](https://github.com/guodong000/react-native-custom-actsheet) - A custom ActionSheet for react-native
+- [react-native-multi-select ★21](https://github.com/hasangilak/react-native-multi-select) - you know select2 on web ? now you have it in react native at your command :)
+- [react-native-custom-checkbox ★13](https://github.com/caroaguilar/react-native-custom-checkbox) - React Native checkbox that can be customize. Works for both Android and iOS.
+- [react-native-dashed-border ★28](https://github.com/chirag04/react-native-dashed-border) - A  element for react-native
+- [react-native-date ★45](https://github.com/nucleartux/react-native-date) - React Native date and time pickers for Android
+- [react-native-timepicker ★18](https://github.com/milasevicius/react-native-timepicker) - React Native timepicker for iOS
+- [react-native-datepicker ★796](https://github.com/xgfe/react-native-datepicker) - React Native date, datetime and time picker for both Android and IOS
+- [react-native-device-display ★100](https://github.com/kkjdaniel/react-native-display-view) - A simple way to create dynamic views through device and display detection, allowing the creation of adaptable and universal apps.
+- [react-native-dial ★28](https://github.com/netbeast/react-native-dial) - A react native reusable and efficient dial knob element.
+- [react-native-dialogs ★362](https://github.com/aakashns/react-native-dialogs) - React Native wrappers for https://github.com/afollestad/material-dialogs
 - [react-native-double-buffer ★3](https://github.com/alinz/react-native-double-buffer) - Simple React Native Double Buffer View
-- [react-native-draggable-drawer ★23](https://github.com/llanox/react-native-draggable-drawer) - DraggableDrawer component for React Native.
-- [react-native-drawer ★1689](https://github.com/root-two/react-native-drawer) - React Native Drawer
-- [react-native-drawer-menu ★17](https://github.com/Tinysymphony/react-native-drawer-menu) - React Native Drawer Menu
-- [react-native-dropbox-chooser ★16](https://github.com/tinycreative/react-native-dropbox-chooser) - React Native dropbox chooser module
-- [react-native-dropdown-android ★61](https://github.com/chymtt/ReactNativeDropdownAndroid) - Simple wrapper for Android's Spinner to use with react-native
-- [react-native-drop-refresh ★25](https://github.com/Obooman/RCTRefreshControl) - A pull down to refresh control for react native.
-- [react-native-dropdownalert ★132](https://github.com/testshallpass/react-native-dropdownalert) - A simple drop down alert with 4 pre-defined types.
-- [react-native-easy-checkbox ★1](https://github.com/BhavanPatel/react-native-easy-checkbox) - Simple CheckBox for react-native
-- [react-native-dropdown ★283](https://github.com/alinz/react-native-dropdown) - A better Select dropdown menu for react-native
-- [react-native-effects-view ★237](https://github.com/voronianski/react-native-effects-view) - ReactNative Component that makes easy to use iOS8 UIVisualEffect
-- [react-native-egg ★87](https://github.com/FuYaoDe/react-native-egg) - A easter egg component implementation simple gestures detection achieve trigger can make your react native app infinitely more fun.
-- [react-native-emoji ★95](https://github.com/jorilallo/react-native-emoji) - Emoji component for React Native
-- [react-native-emoji-picker ★26](https://github.com/yonahforst/react-native-emoji-picker) - Simple Emoji picker for react-native with optional modal-like component
-- [react-native-fade-in-view ★3](https://github.com/robcalcroft/react-native-fade-in-view) - A simple and lightweight RN component that fades in its children
-- [react-native-fading-slides ★30](https://github.com/chagasaway/react-native-fading-slides) - Simple looped fading slides carousel for React Native
-- [react-native-fit-image ★143](https://github.com/huiseoul/react-native-fit-image) - Responsive image component to fit perfectly itself.
-- [react-native-flanimatedimage ★17](https://github.com/nihgwu/react-native-flanimatedimage) - FLAnimatedImage for React Native.
-- [react-native-flex-label ★6](https://github.com/eccolabs/react-native-flex-label) - A text label for React Native that handles multiple lines of text with ellipses truncation as well as vertical alignment within it's view container.
-- [react-native-flexi-radio-button ★7](https://github.com/thegamenicorus/react-native-flexi-radio-button) - Simple and flexible Radio button for React Native
-- [react-native-floating-labels ★82](https://github.com/mayank-patel/react-native-floating-labels) - Reusabe floating lable component for react native
-- [react-native-focus-scroll ★0](https://github.com/c-bata/react-native-focus-scroll) - react-native-focus-scroll can detect which children are focused when scrolling.
-- [react-native-foldview ★816](https://github.com/jmurzy/react-native-foldview) - Animated FoldingCell implementation in React Native
-- [react-native-fontbase ★1](https://github.com/frostney/react-native-fontbase) - Defining font sizes in React Native
-- [react-native-fs-modal ★44](https://github.com/kirkness/react-native-fs-modal) - React native full screen modal component.
-- [react-native-full-screen ★16](https://github.com/Anthonyzou/react-native-full-screen) - React Native FullScreen api and element
-- [react-native-gesture-password ★206](https://github.com/spikef/react-native-gesture-password) - A gesture password component for React Native
-- [react-native-gesture-recognizers ★166](https://github.com/johanneslumpe/react-native-gesture-recognizers) - Gesture recognizer decorators for react-native
-- [react-native-gestures ★104](https://github.com/kiddkai/react-native-gestures) - composable gesture system in react native
-- [react-native-gifted-chat ★2332](https://github.com/FaridSafi/react-native-gifted-chat) - The most complete chat UI for React Native (formerly known as Gifted Messenger)
-- [react-native-gifted-listview ★889](https://github.com/FaridSafi/react-native-gifted-listview) - A ListView that embed some recurrent features like pull-to-refresh, infinite scrolling and more for Android and iOS React-Native apps
-- [react-native-gmaps ★85](https://github.com/teamrota/react-native-gmaps) - React Native Android Google Maps implementation.
-- [react-native-grading ★14](https://github.com/Tinysymphony/react-native-grading) - RN Component for grading scores using ReactART.
-- [react-native-gravatar ★5](https://github.com/lwhiteley/react-native-gravatar) - react-native wrapper for gravatar-api
-- [react-native-super-grid ★54](https://github.com/saleel97/react-native-super-grid) - Responsive Grid View for React Native.
-- [react-native-grid-component ★83](https://github.com/phil-r/react-native-grid-component) - Easy to use grid component for your react-native project. Supports iOS and Android.
-- [react-native-grid-view ★220](https://github.com/lucholaf/react-native-grid-view) - React Native Grid/Collection View component
-- [react-native-grid ★14](https://github.com/thewei/react-native-grid) - The 24-column grid component for react-native
-- [react-native-hero ★19](https://github.com/brh55/react-native-hero) - A hero/banner component with support for dynamic or static images, dynamic sizing, color overlays, and more.
-- [react-native-ibeacon-simulator ★13](https://github.com/williamtran29/react-native-ibeacon-simulator) - React Native Library to simulate device act as an iBeacon
-- [react-native-ichart ★17](https://github.com/AdonRain/react-native-ichart) - ichart for react-native
+- [react-native-draggable-drawer ★34](https://github.com/llanox/react-native-draggable-drawer) - DraggableDrawer component for React Native.
+- [react-native-drawer ★1918](https://github.com/root-two/react-native-drawer) - React Native Drawer
+- [react-native-drawer-menu ★59](https://github.com/Tinysymphony/react-native-drawer-menu) - React Native Drawer Menu
+- [react-native-dropbox-chooser ★18](https://github.com/tinycreative/react-native-dropbox-chooser) - React Native dropbox chooser module
+- [react-native-dropdown-android ★62](https://github.com/chymtt/ReactNativeDropdownAndroid) - Simple wrapper for Android's Spinner to use with react-native
+- [react-native-drop-refresh ★39](https://github.com/Obooman/RCTRefreshControl) - A pull down to refresh control for react native.
+- [react-native-dropdownalert ★455](https://github.com/testshallpass/react-native-dropdownalert) - A simple drop down alert with 4 pre-defined types.
+- [react-native-easy-checkbox ★2](https://github.com/BhavanPatel/react-native-easy-checkbox) - Simple CheckBox for react-native
+- [react-native-dropdown ★404](https://github.com/alinz/react-native-dropdown) - A better Select dropdown menu for react-native
+- [react-native-effects-view ★271](https://github.com/voronianski/react-native-effects-view) - ReactNative Component that makes easy to use iOS8 UIVisualEffect
+- [react-native-egg ★144](https://github.com/FuYaoDe/react-native-egg) - A easter egg component implementation simple gestures detection achieve trigger can make your react native app infinitely more fun.
+- [react-native-emoji ★152](https://github.com/jorilallo/react-native-emoji) - Emoji component for React Native
+- [react-native-emoji-picker ★63](https://github.com/yonahforst/react-native-emoji-picker) - Simple Emoji picker for react-native with optional modal-like component
+- [react-native-fade-in-view ★13](https://github.com/robcalcroft/react-native-fade-in-view) - A simple and lightweight RN component that fades in its children
+- [react-native-fading-slides ★71](https://github.com/chagasaway/react-native-fading-slides) - Simple looped fading slides carousel for React Native
+- [react-native-fit-image ★298](https://github.com/huiseoul/react-native-fit-image) - Responsive image component to fit perfectly itself.
+- [react-native-flanimatedimage ★28](https://github.com/nihgwu/react-native-flanimatedimage) - FLAnimatedImage for React Native.
+- [react-native-flex-label ★7](https://github.com/eccolabs/react-native-flex-label) - A text label for React Native that handles multiple lines of text with ellipses truncation as well as vertical alignment within it's view container.
+- [react-native-flexi-radio-button ★45](https://github.com/thegamenicorus/react-native-flexi-radio-button) - Simple and flexible Radio button for React Native
+- [react-native-floating-labels ★107](https://github.com/mayank-patel/react-native-floating-labels) - Reusabe floating lable component for react native
+- [react-native-focus-scroll ★14](https://github.com/c-bata/react-native-focus-scroll) - react-native-focus-scroll can detect which children are focused when scrolling.
+- [react-native-foldview ★1247](https://github.com/jmurzy/react-native-foldview) - Animated FoldingCell implementation in React Native
+- [react-native-fontbase ★2](https://github.com/frostney/react-native-fontbase) - Defining font sizes in React Native
+- [react-native-fs-modal ★51](https://github.com/kirkness/react-native-fs-modal) - React native full screen modal component.
+- [react-native-full-screen ★31](https://github.com/Anthonyzou/react-native-full-screen) - React Native FullScreen api and element
+- [react-native-gesture-password ★315](https://github.com/spikef/react-native-gesture-password) - A gesture password component for React Native
+- [react-native-gesture-recognizers ★260](https://github.com/johanneslumpe/react-native-gesture-recognizers) - Gesture recognizer decorators for react-native
+- [react-native-gestures ★129](https://github.com/kiddkai/react-native-gestures) - composable gesture system in react native
+- [react-native-gifted-chat ★4048](https://github.com/FaridSafi/react-native-gifted-chat) - The most complete chat UI for React Native (formerly known as Gifted Messenger)
+- [react-native-gifted-listview ★1236](https://github.com/FaridSafi/react-native-gifted-listview) - A ListView that embed some recurrent features like pull-to-refresh, infinite scrolling and more for Android and iOS React-Native apps
+- [react-native-gmaps ★93](https://github.com/teamrota/react-native-gmaps) - React Native Android Google Maps implementation.
+- [react-native-grading ★27](https://github.com/Tinysymphony/react-native-grading) - RN Component for grading scores using ReactART.
+- [react-native-gravatar ★9](https://github.com/lwhiteley/react-native-gravatar) - react-native wrapper for gravatar-api
+- [react-native-super-grid ★146](https://github.com/saleel97/react-native-super-grid) - Responsive Grid View for React Native.
+- [react-native-grid-component ★136](https://github.com/phil-r/react-native-grid-component) - Easy to use grid component for your react-native project. Supports iOS and Android.
+- [react-native-grid-view ★256](https://github.com/lucholaf/react-native-grid-view) - React Native Grid/Collection View component
+- [react-native-grid ★16](https://github.com/thewei/react-native-grid) - The 24-column grid component for react-native
+- [react-native-hero ★91](https://github.com/brh55/react-native-hero) - A hero/banner component with support for dynamic or static images, dynamic sizing, color overlays, and more.
+- [react-native-ibeacon-simulator ★19](https://github.com/williamtran29/react-native-ibeacon-simulator) - React Native Library to simulate device act as an iBeacon
+- [react-native-ichart ★18](https://github.com/AdonRain/react-native-ichart) - ichart for react-native
 - [react-native-icons](https://github.com/corymsmith/react-native-icons), [video](https://www.youtube.com/watch?v=TEdM7IwTT1g#t=50)
-- [react-native-idle-timer ★36](https://github.com/marcshilling/react-native-idle-timer) - An Objective-C bridge that allows you to enable and disable the screen idle timer in your React Native app
+- [react-native-idle-timer ★55](https://github.com/marcshilling/react-native-idle-timer) - An Objective-C bridge that allows you to enable and disable the screen idle timer in your React Native app
 - [react-native-image-container ★0](https://github.com/frostney/react-native-image-container) - Image container for React Native
-- [react-native-image-intent ★27](https://github.com/sonnylazuardi/react-native-image-intent) - Image intent receiver for React Native android
-- [react-native-image-picker ★1862](https://github.com/marcshilling/react-native-image-picker) - A React Native module that allows you to use the native UIImagePickerController UI to select a photo from the device library or directly from the camera.
-- [react-native-image-crop-picker ★606](https://github.com/ivpusic/react-native-image-crop-picker) - iOS/Android image picker with support for multiple images and cropping
-- [react-native-imagewand ★7](https://github.com/NorthFoxz/react-native-imagewand) - image wand for react native
-- [react-native-in-app-notification ★4](https://github.com/robcalcroft/react-native-in-app-notification) - Customisable in-app notification component for React Native
-- [react-native-invertible-scroll-view ★234](https://github.com/exponentjs/react-native-invertible-scroll-view) - An invertible ScrollView for React Native
-- [react-native-item-cell ★46](https://github.com/APSL/react-native-item-cell) - React Native default style iOS item cell
-- [react-native-keyboard-manager ★87](https://github.com/douglasjunior/react-native-keyboard-manager) - Library that allows to prevent issues of keyboard sliding up and cover on React-Native iOS projects.
-- [react-native-keyboard-spacer ★506](https://github.com/Andr3wHur5t/react-native-keyboard-spacer) - Plug and play react-Native keyboard spacer view.
-- [react-native-keyboardevents ★223](https://github.com/johanneslumpe/react-native-keyboardevents) - Monitors keyboard show/hide notifications
-- [react-native-label-select ★23](https://github.com/Tinysymphony/react-native-label-select) - A modal selector for React Native with selected items displayed as labels.
-- [react-native-layout ★33](https://github.com/jerolimov/react-native-layout) - Semantic JSX layout components for react-native
-- [react-native-lightbox ★904](https://github.com/oblador/react-native-lightbox) - a very Slick and modern mobile lightbox implementation
+- [react-native-image-intent ★38](https://github.com/sonnylazuardi/react-native-image-intent) - Image intent receiver for React Native android
+- [react-native-image-picker ★3125](https://github.com/marcshilling/react-native-image-picker) - A React Native module that allows you to use the native UIImagePickerController UI to select a photo from the device library or directly from the camera.
+- [react-native-image-crop-picker ★1525](https://github.com/ivpusic/react-native-image-crop-picker) - iOS/Android image picker with support for multiple images and cropping
+- [react-native-imagewand ★11](https://github.com/NorthFoxz/react-native-imagewand) - image wand for react native
+- [react-native-in-app-notification ★26](https://github.com/robcalcroft/react-native-in-app-notification) - Customisable in-app notification component for React Native
+- [react-native-invertible-scroll-view ★332](https://github.com/exponentjs/react-native-invertible-scroll-view) - An invertible ScrollView for React Native
+- [react-native-item-cell ★62](https://github.com/APSL/react-native-item-cell) - React Native default style iOS item cell
+- [react-native-keyboard-manager ★137](https://github.com/douglasjunior/react-native-keyboard-manager) - Library that allows to prevent issues of keyboard sliding up and cover on React-Native iOS projects.
+- [react-native-keyboard-spacer ★853](https://github.com/Andr3wHur5t/react-native-keyboard-spacer) - Plug and play react-Native keyboard spacer view.
+- [react-native-keyboardevents ★239](https://github.com/johanneslumpe/react-native-keyboardevents) - Monitors keyboard show/hide notifications
+- [react-native-label-select ★47](https://github.com/Tinysymphony/react-native-label-select) - A modal selector for React Native with selected items displayed as labels.
+- [react-native-layout ★39](https://github.com/jerolimov/react-native-layout) - Semantic JSX layout components for react-native
+- [react-native-lightbox ★1404](https://github.com/oblador/react-native-lightbox) - a very Slick and modern mobile lightbox implementation
 - [react-native-link ★7](https://github.com/650Industries/react-native-link) - A link component
-- [react-native-listitem ★73](https://github.com/dancormier/react-native-listitem) - iOS-style listitem component for React Native
-- [react-native-loader-hud ★2](https://github.com/EdgeJay/react-native-loader-hud) - Loader animation library for React Native
-- [react-native-loading ★4](https://github.com/alcat2008/react-native-loading) - A lightweight loading for your React Native app.
-- [react-native-loading-spinner-overlay ★257](https://github.com/niftylettuce/react-native-loading-spinner-overlay) - The only pure React Native, Native iOS and Android loading spinner (progress bar indicator) overlay
-- [react-native-looped-carousel ★554](https://github.com/appintheair/react-native-looped-carousel) - Create looped carousel of views or images
-- [react-native-mapbox-gl ★696](https://github.com/mapbox/react-native-mapbox-gl) - A Mapbox GL react native module for creating custom maps
-- [react-native-maps ★3330](https://github.com/lelandrichardson/react-native-maps) - React Native Map components for iOS + Android
-- [react-native-google-place-picker ★59](https://github.com/q6112345/react-native-google-place-picker) - React Native Wrapper of Google Place Picker for both Android and iOS.
-- [react-native-markdown-editor](https://github.com/kunall17/react-native-markdown-editor/) - Markdown editor like github comment editor (contains preview, markdown buttons)
-- [react-native-marquee-label ★37](https://github.com/remobile/react-native-marquee-label) - A marquee label for react-native
-- [react-native-masked-view ★33](https://github.com/gilbox/react-native-masked-view) - A  element for react-native
-- [react-native-masked-text ★41](https://github.com/benhurott/react-native-masked-text) - A simple masked text and input text component for React-Native.
-- [react-native-text-input-mask](https://github.com/ivanzotov/react-native-text-input-mask) - Text input mask for Android and iOS, native implementation RedMadRobot libraries
-- [react-native-masonry ★323](https://github.com/brh55/react-native-masonry) - A masonry~ish layout for rendering images.
-- [react-native-material-design ★1929](https://github.com/react-native-material-design/react-native-material-design) - React Native Material Design Components
-- [react-native-material-ui ★480](https://github.com/xotahal/react-native-material-ui) - Highly customizable material design components for React Native
-- [react-native-material-kit ★2420](https://github.com/xinthink/react-native-material-kit) - Bringing Material Design to React Native
-- [react-native-match-media ★12](https://github.com/tuckerconnelly/match-media-mocks) - window.matchMedia mock for React Native
-- [react-native-message-composer ★41](https://github.com/anarchicknight/react-native-message-composer) - React Native module bridge to iOS MFMessageComposeViewController
-- [react-native-md-textinput ★138](https://github.com/evblurbs/react-native-md-textinput) - React Native TextInput styled with Material Design.
-- [react-native-modalbox ★808](https://github.com/maxs15/react-native-modalbox) - A  component for react-native
-- [react-native-modal-dropdown ★102](https://github.com/sohobloo/react-native-modal-dropdown) - A react-native dropdown/picker/selector component for both Android & iOS.
-- [react-native-modal-picker ★142](https://github.com/d-a-n/react-native-modal-picker) - A cross-platform (iOS / Android), selector/picker component for React Native that is highly customizable and supports sections.
-- [react-native-multi-slider ★82](https://github.com/JackDanielsAndCode/react-native-multi-slider) - Pure JS slider component with multiple markers for React Native
-- [react-native-multiselect ★6](https://github.com/robcalcroft/react-native-multiselect) - A simple multi select component with events and a flexible API.
-- [react-native-multiple-choice ★34](https://github.com/d-a-n/react-native-multiple-choice) - A cross-platform (iOS / Android) single and multiple-choice React Native component.
-- [react-native-nested-stylesheet ★54](https://github.com/pjjanak/react-native-nested-stylesheets) - Nestable stylesheets for react-native.
-- [react-native-newsticker ★21](https://github.com/moschan/react-native-newsticker) - The News Ticker component for React Native
-- [react-native-nmrangeslider-ios ★19](https://github.com/Enrise/react-native-nmrangeslider-ios) - The NMRangeSlider component for React Native
-- [react-native-open-maps ★19](https://github.com/brh55/react-native-open-maps) - A simple lib to open up the corresponding map application (Google or Apple Maps) from a set of coordinates (latitude & longitude) within react-native
-- [react-native-offline-mode ★55](https://github.com/rauchy/react-native-offline-mode) - Swap your app with an offline version while there's no connectivity
-- [react-native-orientation-controller ★19](https://github.com/inProgress-team/react-native-orientation-controller) - A react-native library for obtaining and controlling the current device and application orientation
-- [react-native-orientation-listener ★117](https://github.com/walmartreact/react-native-orientation-listener) - A react-native library for obtaining current device orientation
-- [react-native-orientation ★407](https://github.com/yamill/react-native-orientation) - Listen to device orientation changes in react-native and set preferred orientation on screen to screen basis
-- [react-native-page-control ★86](https://github.com/silentcloud/react-native-page-control) - React native page control, like ios  UIPageControl
-- [react-native-page-swiper ★68](https://github.com/fixt/react-native-page-swiper) - Page Swiper component for React Native.
-- [react-native-parallax ★298](https://github.com/oblador/react-native-parallax) - Parallax effects for React Native using Animated API
-- [react-native-parallax-scroll-view ★622](https://github.com/jaysoo/react-native-parallax-scroll-view) - A ScrollView-like component with parallax and sticky header support.
-- [react-native-parallax-swiper ★12](https://github.com/zachgibson/react-native-parallax-swiper) - Configurable parallax swiper based on an iOS pattern. Uses Native Driver for super smooth parallax.
-- [react-native-parsed-text ★239](https://github.com/taskrabbit/react-native-parsed-text) - Parse text and make them into multiple React Native Text elements
-- [react-native-pathjs-charts ★211](https://github.com/capitalone/react-native-pathjs-charts) - Android and iOS charts based on react-native-svg and paths-js
-- [react-native-pdf-view ★122](https://github.com/cnjon/react-native-pdf-view) - view pdf file using react-native
-- [react-native-phone-input ★1](https://github.com/thegamenicorus/react-native-phone-input) - Phone input box for React Native
-- [react-native-phone-picker ★31](https://github.com/Spikef/react-native-phone-picker) - a quick phone picker control
-- [react-native-photo-browser ★278](https://github.com/halilb/react-native-photo-browser) - Local and remote photo browser with captions, selections and grid view support.
-- [react-native-photo-grid ★9](https://github.com/christopherabouabdo/react-native-photo-grid) - React Native component that handles the complexities of building a grid of photos with a flexible number of photos per row.
-- [react-native-picker-android ★55](https://github.com/beefe/react-native-picker-android) - react-native-picker-android
-- [react-native-picker ★324](https://github.com/beefe/react-native-picker) - react-native-picker
-- [react-native-picker-xg ★24](https://github.com/xgfe/react-native-picker-xg) - A picker for both Android and iOS
-- [react-native-piechart ★11](https://github.com/frostney/react-native-piechart) - A  component for React Native
-- [react-native-popover-haobtc ★230](https://github.com/jeanregisser/react-native-popover) - A  component for react-native
-- [react-native-popup ★91](https://github.com/beefe/react-native-popup) - popup for react-native
-- [react-native-popupwindow ★27](https://github.com/beefe/react-native-popupwindow) - Android PopupWindow for react-native module
-- [react-native-privacy-snapshot ★57](https://github.com/kayla-tech/react-native-privacy-snapshot) - Obscure passwords and other sensitive personal information when a react-native app transitions to the background
-- [react-native-progress-bar ★134](https://github.com/lwansbrough/react-native-progress-bar) - An animated progress bar component for React Native
-- [react-native-progress-button ★1](https://github.com/xinghui0000/react-native-progress-button) - A react native button component that can show progress.
-- [react-native-progress-circular ★23](https://github.com/andy9775/React-Native-CircularProgress) - A pure React Native Component for circular progress bars for both iOS and Android.
-- [react-native-progress-hud ★155](https://github.com/naoufal/react-native-progress-hud) - A clean and lightweight progress HUD for your React Native app
-- [react-native-pulse-loader ★43](https://github.com/mastermoo/react-native-pulse-loader) - Tinder like loader for your React Native app
-- [react-native-qrcode ★131](https://github.com/cssivision/react-native-qrcode) - react-native qrcode generator
-- [react-native-qrcode-svg ★97](https://github.com/awesomejerry/react-native-qrcode-svg) - A QR Code generator for React Native based on react-native-svg and node-qrcode.
-- [react-native-quiltview ★7](https://github.com/mmslate/react-native-quiltview) - Native iOS UICollectionView wrapper with RFQuiltLayout for React Native
-- [react-native-radial-menu ★67](https://github.com/omulet/react-native-radial-menu) - A Radial Menu optimized for touch interfaces
-- [react-native-radio-button-classic ★34](https://github.com/pressly/react-native-radio-button-classic) - Bring Classic Radio to React-Native
-- [react-native-radio-buttons ★214](https://github.com/ArnaudRinquin/react-native-radio-buttons) - A react component to implement custom radio buttons-like behaviors: multiple options, only on can be selected at once.
-- [react-native-rebound-scrollview ★8](https://github.com/jaxchow/react-native-rebound-scrollview) - React Native Android ReboundScrollView implementation.
-- [react-native-refresher ★320](https://github.com/syrusakbary/react-native-refresher) - A React Native pull to refresh ListView completely written in js. Also supports custom animations.
-- [react-native-relative-units ★5](https://github.com/benzhe/react-native-relative-units) - Relative units for React Native
-- [react-native-responsive-image ★190](https://github.com/Dharmoslap/react-native-responsive-image) - Most elegant Responsive Image component
-- [react-native-root-modal ★154](https://github.com/magicismight/react-native-root-modal) - react native modal component
+- [react-native-listitem ★83](https://github.com/dancormier/react-native-listitem) - iOS-style listitem component for React Native
+- [react-native-loader-hud ★3](https://github.com/EdgeJay/react-native-loader-hud) - Loader animation library for React Native
+- [react-native-loading ★5](https://github.com/alcat2008/react-native-loading) - A lightweight loading for your React Native app.
+- [react-native-loading-spinner-overlay ★595](https://github.com/niftylettuce/react-native-loading-spinner-overlay) - The only pure React Native, Native iOS and Android loading spinner (progress bar indicator) overlay
+- [react-native-looped-carousel ★914](https://github.com/appintheair/react-native-looped-carousel) - Create looped carousel of views or images
+- [react-native-mapbox-gl ★1115](https://github.com/mapbox/react-native-mapbox-gl) - A Mapbox GL react native module for creating custom maps
+- [react-native-maps ★5996](https://github.com/lelandrichardson/react-native-maps) - React Native Map components for iOS + Android
+- [react-native-google-place-picker ★112](https://github.com/q6112345/react-native-google-place-picker) - React Native Wrapper of Google Place Picker for both Android and iOS.
+- [react-native-markdown-editor ★13](https://github.com/kunall17/react-native-markdown-editor) - Markdown editor like github comment editor (contains preview, markdown buttons)
+- [react-native-marquee-label ★75](https://github.com/remobile/react-native-marquee-label) - A marquee label for react-native
+- [react-native-masked-view ★46](https://github.com/gilbox/react-native-masked-view) - A  element for react-native
+- [react-native-masked-text ★168](https://github.com/benhurott/react-native-masked-text) - A simple masked text and input text component for React-Native.
+- [react-native-text-input-mask ★139](https://github.com/ivanzotov/react-native-text-input-mask) - Text input mask for Android and iOS, native implementation RedMadRobot libraries
+- [react-native-masonry ★511](https://github.com/brh55/react-native-masonry) - A masonry~ish layout for rendering images.
+- [react-native-material-design ★2619](https://github.com/react-native-material-design/react-native-material-design) - React Native Material Design Components
+- [react-native-material-ui ★1244](https://github.com/xotahal/react-native-material-ui) - Highly customizable material design components for React Native
+- [react-native-material-kit ★3383](https://github.com/xinthink/react-native-material-kit) - Bringing Material Design to React Native
+- [react-native-match-media ★19](https://github.com/tuckerconnelly/match-media-mocks) - window.matchMedia mock for React Native
+- [react-native-message-composer ★44](https://github.com/anarchicknight/react-native-message-composer) - React Native module bridge to iOS MFMessageComposeViewController
+- [react-native-md-textinput ★241](https://github.com/evblurbs/react-native-md-textinput) - React Native TextInput styled with Material Design.
+- [react-native-modalbox ★1429](https://github.com/maxs15/react-native-modalbox) - A  component for react-native
+- [react-native-modal-dropdown ★378](https://github.com/sohobloo/react-native-modal-dropdown) - A react-native dropdown/picker/selector component for both Android & iOS.
+- [react-native-modal-picker ★261](https://github.com/d-a-n/react-native-modal-picker) - A cross-platform (iOS / Android), selector/picker component for React Native that is highly customizable and supports sections.
+- [react-native-multi-slider ★119](https://github.com/JackDanielsAndCode/react-native-multi-slider) - Pure JS slider component with multiple markers for React Native
+- [react-native-multiselect ★12](https://github.com/robcalcroft/react-native-multiselect) - A simple multi select component with events and a flexible API.
+- [react-native-multiple-choice ★45](https://github.com/d-a-n/react-native-multiple-choice) - A cross-platform (iOS / Android) single and multiple-choice React Native component.
+- [react-native-nested-stylesheet ★60](https://github.com/pjjanak/react-native-nested-stylesheets) - Nestable stylesheets for react-native.
+- [react-native-newsticker ★30](https://github.com/moschan/react-native-newsticker) - The News Ticker component for React Native
+- [react-native-nmrangeslider-ios ★24](https://github.com/Enrise/react-native-nmrangeslider-ios) - The NMRangeSlider component for React Native
+- [react-native-open-maps ★25](https://github.com/brh55/react-native-open-maps) - A simple lib to open up the corresponding map application (Google or Apple Maps) from a set of coordinates (latitude & longitude) within react-native
+- [react-native-offline-mode ★96](https://github.com/rauchy/react-native-offline-mode) - Swap your app with an offline version while there's no connectivity
+- [react-native-orientation-controller ★22](https://github.com/inProgress-team/react-native-orientation-controller) - A react-native library for obtaining and controlling the current device and application orientation
+- [react-native-orientation-listener ★133](https://github.com/walmartreact/react-native-orientation-listener) - A react-native library for obtaining current device orientation
+- [react-native-orientation ★764](https://github.com/yamill/react-native-orientation) - Listen to device orientation changes in react-native and set preferred orientation on screen to screen basis
+- [react-native-page-control ★119](https://github.com/silentcloud/react-native-page-control) - React native page control, like ios  UIPageControl
+- [react-native-page-swiper ★74](https://github.com/fixt/react-native-page-swiper) - Page Swiper component for React Native.
+- [react-native-parallax ★387](https://github.com/oblador/react-native-parallax) - Parallax effects for React Native using Animated API
+- [react-native-parallax-scroll-view ★1028](https://github.com/jaysoo/react-native-parallax-scroll-view) - A ScrollView-like component with parallax and sticky header support.
+- [react-native-parallax-swiper ★80](https://github.com/zachgibson/react-native-parallax-swiper) - Configurable parallax swiper based on an iOS pattern. Uses Native Driver for super smooth parallax.
+- [react-native-parsed-text ★383](https://github.com/taskrabbit/react-native-parsed-text) - Parse text and make them into multiple React Native Text elements
+- [react-native-pathjs-charts ★649](https://github.com/capitalone/react-native-pathjs-charts) - Android and iOS charts based on react-native-svg and paths-js
+- [react-native-pdf-view ★258](https://github.com/cnjon/react-native-pdf-view) - view pdf file using react-native
+- [react-native-phone-input ★54](https://github.com/thegamenicorus/react-native-phone-input) - Phone input box for React Native
+- [react-native-phone-picker ★49](https://github.com/Spikef/react-native-phone-picker) - a quick phone picker control
+- [react-native-photo-browser ★446](https://github.com/halilb/react-native-photo-browser) - Local and remote photo browser with captions, selections and grid view support.
+- [react-native-photo-grid ★24](https://github.com/christopherabouabdo/react-native-photo-grid) - React Native component that handles the complexities of building a grid of photos with a flexible number of photos per row.
+- [react-native-picker-android ★63](https://github.com/beefe/react-native-picker-android) - react-native-picker-android
+- [react-native-picker ★748](https://github.com/beefe/react-native-picker) - react-native-picker
+- [react-native-picker-xg ★58](https://github.com/xgfe/react-native-picker-xg) - A picker for both Android and iOS
+- [react-native-piechart ★10](https://github.com/frostney/react-native-piechart) - A  component for React Native
+- [react-native-popover-haobtc ★374](https://github.com/jeanregisser/react-native-popover) - A  component for react-native
+- [react-native-popup ★137](https://github.com/beefe/react-native-popup) - popup for react-native
+- [react-native-popupwindow ★37](https://github.com/beefe/react-native-popupwindow) - Android PopupWindow for react-native module
+- [react-native-privacy-snapshot ★93](https://github.com/kayla-tech/react-native-privacy-snapshot) - Obscure passwords and other sensitive personal information when a react-native app transitions to the background
+- [react-native-progress-bar ★181](https://github.com/lwansbrough/react-native-progress-bar) - An animated progress bar component for React Native
+- [react-native-progress-button ★4](https://github.com/xinghui0000/react-native-progress-button) - A react native button component that can show progress.
+- [react-native-progress-circular ★36](https://github.com/andy9775/React-Native-CircularProgress) - A pure React Native Component for circular progress bars for both iOS and Android.
+- [react-native-progress-hud ★192](https://github.com/naoufal/react-native-progress-hud) - A clean and lightweight progress HUD for your React Native app
+- [react-native-pulse-loader ★105](https://github.com/mastermoo/react-native-pulse-loader) - Tinder like loader for your React Native app
+- [react-native-qrcode ★351](https://github.com/cssivision/react-native-qrcode) - react-native qrcode generator
+- [react-native-qrcode-svg ★113](https://github.com/awesomejerry/react-native-qrcode-svg) - A QR Code generator for React Native based on react-native-svg and node-qrcode.
+- [react-native-quiltview ★8](https://github.com/mmslate/react-native-quiltview) - Native iOS UICollectionView wrapper with RFQuiltLayout for React Native
+- [react-native-radial-menu ★108](https://github.com/omulet/react-native-radial-menu) - A Radial Menu optimized for touch interfaces
+- [react-native-radio-button-classic ★40](https://github.com/pressly/react-native-radio-button-classic) - Bring Classic Radio to React-Native
+- [react-native-radio-buttons ★343](https://github.com/ArnaudRinquin/react-native-radio-buttons) - A react component to implement custom radio buttons-like behaviors: multiple options, only on can be selected at once.
+- [react-native-rebound-scrollview ★11](https://github.com/jaxchow/react-native-rebound-scrollview) - React Native Android ReboundScrollView implementation.
+- [react-native-refresher ★376](https://github.com/syrusakbary/react-native-refresher) - A React Native pull to refresh ListView completely written in js. Also supports custom animations.
+- [react-native-relative-units ★8](https://github.com/benzhe/react-native-relative-units) - Relative units for React Native
+- [react-native-responsive-image ★272](https://github.com/Dharmoslap/react-native-responsive-image) - Most elegant Responsive Image component
+- [react-native-root-modal ★248](https://github.com/magicismight/react-native-root-modal) - react native modal component
 - [react-native-scene-manager ★2](https://github.com/alinz/react-native-scene-manager) - Simple Scene Manager for React-Native
-- [react-native-scrollable-decorator ★25](https://github.com/exponentjs/react-native-scrollable-decorator) - A standard interface for your scrollable React Native components, making it easier to compose components
-- [react-native-scrollable-mixin ★67](https://github.com/exponentjs/react-native-scrollable-mixin) - A standard interface for your scrollable React Native components, making it easier to compose components.
-- [react-native-scrollable-tab-view ★3063](https://github.com/brentvatne/react-native-scrollable-tab-view) - This is probably my favorite navigation pattern on Android, I wish it were more common on iOS! This is a very simple JavaScript-only implementation of it for React Native. For more information about how the animations behind this work, check out the Rebou
-- [react-native-scrollview-lazyload ★54](https://github.com/IskenHuang/react-native-scrollview-lazyload) - react-native scrollview with image lazy load
-- [react-native-infinite-scrollview ★31](https://github.com/baspellis/react-native-infinite-scrollview) - ScrollView with infinite paged scrolling (no looping)
-- [react-native-search-bar ★403](https://github.com/umhan35/react-native-search-bar) - The native search bar for react native.
-- [react-native-searchbar ★146](https://github.com/localz/react-native-searchbar) - An animated search bar for react native with inbuilt search (iOS and Android)
-- [react-native-search ★13](https://github.com/StevenIseki/react-native-search) - Native Search component for react native.
+- [react-native-scrollable-decorator ★31](https://github.com/exponentjs/react-native-scrollable-decorator) - A standard interface for your scrollable React Native components, making it easier to compose components
+- [react-native-scrollable-mixin ★83](https://github.com/exponentjs/react-native-scrollable-mixin) - A standard interface for your scrollable React Native components, making it easier to compose components.
+- [react-native-scrollable-tab-view ★4579](https://github.com/brentvatne/react-native-scrollable-tab-view) - This is probably my favorite navigation pattern on Android, I wish it were more common on iOS! This is a very simple JavaScript-only implementation of it for React Native. For more information about how the animations behind this work, check out the Rebou
+- [react-native-scrollview-lazyload ★65](https://github.com/IskenHuang/react-native-scrollview-lazyload) - react-native scrollview with image lazy load
+- [react-native-infinite-scrollview ★44](https://github.com/baspellis/react-native-infinite-scrollview) - ScrollView with infinite paged scrolling (no looping)
+- [react-native-search-bar ★556](https://github.com/umhan35/react-native-search-bar) - The native search bar for react native.
+- [react-native-searchbar ★195](https://github.com/localz/react-native-searchbar) - An animated search bar for react native with inbuilt search (iOS and Android)
+- [react-native-search ★15](https://github.com/StevenIseki/react-native-search) - Native Search component for react native.
 - [react-native-seekbar-android ★10](https://github.com/DispatcherInc/react-native-seekbar-android) - A React Native wrapper Android's SeekBar
-- [react-native-custom-segmented-control ★57](https://github.com/wix/react-native-custom-segmented-control) - Native UI iOS component for Segmented Control with custom style
-- [react-native-segmented-view ★113](https://github.com/lelandrichardson/react-native-segmented-view) - Segmented View for React Native (with animation)
+- [react-native-custom-segmented-control ★96](https://github.com/wix/react-native-custom-segmented-control) - Native UI iOS component for Segmented Control with custom style
+- [react-native-segmented-view ★144](https://github.com/lelandrichardson/react-native-segmented-view) - Segmented View for React Native (with animation)
 - [react-native-select-box ★0](https://github.com/akiran/react-native-select-box) - react native select box
-- [react-native-selectme ★98](https://github.com/gs-akhan/react-native-select) - A better Select dropdown menu for react-native
-- [react-native-shared-preferences ★36](https://github.com/sriraman/react-native-shared-preferences) - Android's Native key value storage system in React Native
-- [react-native-showdown ★16](https://github.com/jerolimov/react-native-showdown) - React-native component which renders markdown into a webview!
-- [react-native-simple-button ★5](https://github.com/remobile/react-native-simple-button) - A simple react-native button
-- [react-native-simple-dialogs ★2](https://github.com/douglasjunior/react-native-simple-dialogs) - Cross-platform simple dialogs for React Native based on the Modal component.
-- [react-native-simple-picker ★11](https://github.com/puredazzle/react-native-simple-picker) - A simple react-native select picker
-- [react-native-simple-router ★213](https://github.com/react-native-simple-router-community/react-native-simple-router) - A community maintained router component for React Native
-- [react-native-simple-stepper ★17](https://github.com/testshallpass/react-native-simple-stepper) - A super simple react-native implementation of the UIStepper iOS control.
-- [react-native-simpledialog-android ★39](https://github.com/lucasferreira/react-native-simpledialog-android) - React Native Android module to use Android's AlertDialog - same idea of AlertIOS
-- [react-native-size-matters ★31](https://github.com/nirsky/react-native-size-matters) - A React-Native utility belt for scaling the size your apps UI across different sized devices.
-- [react-native-sketch ★109](https://github.com/jgrancher/react-native-sketch) - A react-native &lt;Sketch /> component to draw with touch events.
-- [react-native-slack-webhook ★24](https://github.com/xcarpentier/react-native-slack-webhook) - Follow some activities (new user, payment, ...) from your app via Slack and this webhook lib.
-- [react-native-slidable-tab-bar ★23](https://github.com/pwbrown/react-native-slidable-tab-bar) - Slidable tab bar for instant view rendering(react-native)
-- [react-native-slider ★328](https://github.com/jeanregisser/react-native-slider) - A pure JavaScript  component for react-native
-- [react-native-slot-machine ★31](https://github.com/atlanteh/react-native-slot-machine) - A text slot machine component for react-native
-- [react-native-sortable-list ★171](https://github.com/gitim/react-native-sortable-list) A sortable list for react native with both vertical and horizontal direction support.
-- [react-native-spinkit ★657](https://github.com/maxs15/react-native-spinkit) - A collection of animated loading indicators for React Native
-- [react-native-splashscreen ★244](https://github.com/remobile/react-native-splashscreen) - A splash screen for react-native
-- [react-native-square-view ★17](https://github.com/Shuangzuan/react-native-square-view) - A square view component for react native.
-- [react-native-star-rating ★126](https://github.com/djchie/react-native-star-rating) - A React Native component for generating and displaying interactive star ratings
-- [react-native-starrating ★16](https://github.com/bluesky0109/react-native-starRating) - a react-native component for display interactive star ratings
-- [react-native-store-view ★7](https://github.com/rh389/react-native-store-view) - Wraps SKStoreProductViewController for use in react-native projects
-- [react-native-streetview ★20](https://github.com/nesterapp/react-native-streetview) - Google's Panorama/StreetView component for iOS and Android.
-- [react-native-stylesheet-xg ★5](https://github.com/xgfe/react-native-stylesheet-xg) - extension stylesheet for cross platforms and responsive
-- [react-native-svg ★941](https://github.com/magicismight/react-native-svg) - SVG library that works on both iOS & Android
-- [react-native-svg-charts](https://github.com/JesperLekland/react-native-svg-charts) - One library to rule all charts for React Native 
-- [react-native-swipeout ★891](https://github.com/dancormier/react-native-swipeout) - iOS-style swipeout buttons behind component
-- [react-native-swipeview ★3](https://github.com/rishabhbhatia/react-native-swipeview) - SwipeView component used to perform actions like swipe to delete, works on iOS and Android
-- [react-native-swipe-a-lot ★51](https://github.com/nickjanssen/react-native-swipe-a-lot) - A swipe component for React Native that works on iOS and Android.
-- [react-native-swiper2 ★77](https://github.com/sunnylqm/react-native-swiper2) - Swiper component for React Native. Supersede react-native-swiper
-- [react-native-swiper ★3000](https://github.com/leecade/react-native-swiper) - The best Swiper component for React Native.
-- [react-native-swiper-animated ★8](https://github.com/chitezh/react-native-swiper-animated) - Tinder-like swiper for react-native
-- [react-native-tab ★102](https://github.com/vczero/react-native-tab) - react-native-tab is a simple module for add a "Tab Menu" to your React Native app.
-- [react-native-tabbar ★214](https://github.com/alinz/react-native-tabbar) - Tab bar with more freedom
-- [react-native-tableview-simple ★146](https://github.com/Purii/react-native-tableview-simple) - React Native component for TableView made with pure CSS
-- [react-native-tableview ★712](https://github.com/aksonov/react-native-tableview) - Native iOS TableView wrapper for React Native
-- [react-native-tabs ★474](https://github.com/aksonov/react-native-tabs) - React Native platform-independent tabs. Could be used for bottom tab bars as well as sectioned views (with tab buttons)
-- [react-native-textinput-effects ★1138](https://github.com/halilb/react-native-textinput-effects) - Text inputs with custom label and icon animations for iOS and android. Built by react native and inspired by Codrops.
-- [react-native-textinput-utils ★42](https://github.com/DickyT/react-native-textinput-utils) - A react native extension which allows you to control TextInput better.
-- [react-native-tilt ★6](https://github.com/psicotropicos/react-native-tilt) - Tilt effect with accelerometer for React Native components.
-- [react-native-timeago ★148](https://github.com/TylerLH/react-native-timeago) - Auto-updating timeago component for React Native
-- [react-native-timeline-listview ★3](https://github.com/thegamenicorus/react-native-timeline-listview) - Timeline component for React Native App
-- [react-native-timer-mixin ★158](https://github.com/reactjs/react-timer-mixin) - TimerMixin provides timer functions for executing code in the future that are safely cleaned up when the component unmounts. This is a fork that includes react-native InteractionManager support.
-- [react-native-tinder-swipe-cards ★400](https://github.com/meteor-factory/react-native-tinder-swipe-cards) - Tinder card style swiping.
-- [react-native-thumbnail ★7](https://github.com/phuochau/react-native-thumbnail) - Get thumbnail from local media.
-- [react-native-toast ★196](https://github.com/remobile/react-native-toast) - A android like toast for react-native support for ios and android
-- [react-native-toolkit ★35](https://github.com/marty-wang/react-native-toolkit) - A collection of common UI components for react native mobile apps.
-- [react-native-tooltip ★120](https://github.com/chirag04/react-native-tooltip) - A react-native wrapper for showing tooltips
-- [react-native-touchable-bounce ★19](https://github.com/grabbou/react-native-touchable-bounce) - React Native Touchable Bounce
+- [react-native-selectme ★149](https://github.com/gs-akhan/react-native-select) - A better Select dropdown menu for react-native
+- [react-native-shared-preferences ★69](https://github.com/sriraman/react-native-shared-preferences) - Android's Native key value storage system in React Native
+- [react-native-showdown ★21](https://github.com/jerolimov/react-native-showdown) - React-native component which renders markdown into a webview!
+- [react-native-simple-button ★7](https://github.com/remobile/react-native-simple-button) - A simple react-native button
+- [react-native-simple-dialogs ★31](https://github.com/douglasjunior/react-native-simple-dialogs) - Cross-platform simple dialogs for React Native based on the Modal component.
+- [react-native-simple-picker ★42](https://github.com/puredazzle/react-native-simple-picker) - A simple react-native select picker
+- [react-native-simple-router ★240](https://github.com/react-native-simple-router-community/react-native-simple-router) - A community maintained router component for React Native
+- [react-native-simple-stepper ★35](https://github.com/testshallpass/react-native-simple-stepper) - A super simple react-native implementation of the UIStepper iOS control.
+- [react-native-simpledialog-android ★41](https://github.com/lucasferreira/react-native-simpledialog-android) - React Native Android module to use Android's AlertDialog - same idea of AlertIOS
+- [react-native-size-matters ★84](https://github.com/nirsky/react-native-size-matters) - A React-Native utility belt for scaling the size your apps UI across different sized devices.
+- [react-native-sketch ★341](https://github.com/jgrancher/react-native-sketch) - A react-native &lt;Sketch /> component to draw with touch events.
+- [react-native-slack-webhook ★34](https://github.com/xcarpentier/react-native-slack-webhook) - Follow some activities (new user, payment, ...) from your app via Slack and this webhook lib.
+- [react-native-slidable-tab-bar ★32](https://github.com/pwbrown/react-native-slidable-tab-bar) - Slidable tab bar for instant view rendering(react-native)
+- [react-native-slider ★573](https://github.com/jeanregisser/react-native-slider) - A pure JavaScript  component for react-native
+- [react-native-slot-machine ★32](https://github.com/atlanteh/react-native-slot-machine) - A text slot machine component for react-native
+- [react-native-sortable-list ★221](https://github.com/gitim/react-native-sortable-list) A sortable list for react native with both vertical and horizontal direction support.
+- [react-native-spinkit ★1110](https://github.com/maxs15/react-native-spinkit) - A collection of animated loading indicators for React Native
+- [react-native-splashscreen ★317](https://github.com/remobile/react-native-splashscreen) - A splash screen for react-native
+- [react-native-square-view ★20](https://github.com/Shuangzuan/react-native-square-view) - A square view component for react native.
+- [react-native-star-rating ★287](https://github.com/djchie/react-native-star-rating) - A React Native component for generating and displaying interactive star ratings
+- [react-native-starrating ★21](https://github.com/bluesky0109/react-native-starRating) - a react-native component for display interactive star ratings
+- [react-native-store-view ★16](https://github.com/rh389/react-native-store-view) - Wraps SKStoreProductViewController for use in react-native projects
+- [react-native-streetview ★35](https://github.com/nesterapp/react-native-streetview) - Google's Panorama/StreetView component for iOS and Android.
+- [react-native-stylesheet-xg ★6](https://github.com/xgfe/react-native-stylesheet-xg) - extension stylesheet for cross platforms and responsive
+- [react-native-svg ★1897](https://github.com/magicismight/react-native-svg) - SVG library that works on both iOS & Android
+- [react-native-svg-charts ★28](https://github.com/JesperLekland/react-native-svg-charts) - One library to rule all charts for React Native
+- [react-native-swipeout ★1486](https://github.com/dancormier/react-native-swipeout) - iOS-style swipeout buttons behind component
+- [react-native-swipeview ★41](https://github.com/rishabhbhatia/react-native-swipeview) - SwipeView component used to perform actions like swipe to delete, works on iOS and Android
+- [react-native-swipe-a-lot ★84](https://github.com/nickjanssen/react-native-swipe-a-lot) - A swipe component for React Native that works on iOS and Android.
+- [react-native-swiper2 ★85](https://github.com/sunnylqm/react-native-swiper2) - Swiper component for React Native. Supersede react-native-swiper
+- [react-native-swiper ★4915](https://github.com/leecade/react-native-swiper) - The best Swiper component for React Native.
+- [react-native-swiper-animated ★87](https://github.com/chitezh/react-native-swiper-animated) - Tinder-like swiper for react-native
+- [react-native-tab ★137](https://github.com/vczero/react-native-tab) - react-native-tab is a simple module for add a "Tab Menu" to your React Native app.
+- [react-native-tabbar ★242](https://github.com/alinz/react-native-tabbar) - Tab bar with more freedom
+- [react-native-tableview-simple ★222](https://github.com/Purii/react-native-tableview-simple) - React Native component for TableView made with pure CSS
+- [react-native-tableview ★877](https://github.com/aksonov/react-native-tableview) - Native iOS TableView wrapper for React Native
+- [react-native-tabs ★626](https://github.com/aksonov/react-native-tabs) - React Native platform-independent tabs. Could be used for bottom tab bars as well as sectioned views (with tab buttons)
+- [react-native-textinput-effects ★1436](https://github.com/halilb/react-native-textinput-effects) - Text inputs with custom label and icon animations for iOS and android. Built by react native and inspired by Codrops.
+- [react-native-textinput-utils ★62](https://github.com/DickyT/react-native-textinput-utils) - A react native extension which allows you to control TextInput better.
+- [react-native-tilt ★12](https://github.com/psicotropicos/react-native-tilt) - Tilt effect with accelerometer for React Native components.
+- [react-native-timeago ★209](https://github.com/TylerLH/react-native-timeago) - Auto-updating timeago component for React Native
+- [react-native-timeline-listview ★255](https://github.com/thegamenicorus/react-native-timeline-listview) - Timeline component for React Native App
+- [react-native-timer-mixin ★219](https://github.com/reactjs/react-timer-mixin) - TimerMixin provides timer functions for executing code in the future that are safely cleaned up when the component unmounts. This is a fork that includes react-native InteractionManager support.
+- [react-native-tinder-swipe-cards ★707](https://github.com/meteor-factory/react-native-tinder-swipe-cards) - Tinder card style swiping.
+- [react-native-thumbnail ★22](https://github.com/phuochau/react-native-thumbnail) - Get thumbnail from local media.
+- [react-native-toast ★285](https://github.com/remobile/react-native-toast) - A android like toast for react-native support for ios and android
+- [react-native-toolkit ★38](https://github.com/marty-wang/react-native-toolkit) - A collection of common UI components for react native mobile apps.
+- [react-native-tooltip ★161](https://github.com/chirag04/react-native-tooltip) - A react-native wrapper for showing tooltips
+- [react-native-touchable-bounce ★41](https://github.com/grabbou/react-native-touchable-bounce) - React Native Touchable Bounce
 - [react-native-touchable-set-active ★28](https://github.com/jmstout/react-native-TouchableSetActive) - Touchable component for React Native that enables more advanced styling by setting an active state. Most useful for building your own touchable/button components on top of.
-- [react-native-touch-visualizer ★4](https://github.com/zachgibson/react-native-touch-visualizer) - Visualize touches and drags on React Native apps for iOS.
-- [react-native-triangle ★32](https://github.com/Jpoliachik/react-native-triangle) - draw triangle views in react native
-- [react-native-tween-animation ★35](https://github.com/kirkness/react-native-tween-animation) - A simple react native state tween animation module.
-- [react-native-ui-kitten ★1117](https://github.com/akveo/react-native-ui-kitten) - Customizable and reusable react-native component kit
-- [react-native-vector-icons ★4008](https://github.com/oblador/react-native-vector-icons) - Customizable Icons for React Native with support for NavBar/TabBar, image source and full styling. Choose from 3000+ bundled icons or use your own.
-- [react-native-view ★25](https://github.com/i6mi6/react-native-view) - Lightweight View component for quick styling.
-- [react-native-viewpager ★868](https://github.com/race604/react-native-viewpager) - ViewPager component for React Native
-- [react-native-viewport-units ★50](https://github.com/jmstout/react-native-viewport-units) - Incredibly simple utility for (sort of) using viewport units with React Native.
+- [react-native-touch-visualizer ★30](https://github.com/zachgibson/react-native-touch-visualizer) - Visualize touches and drags on React Native apps for iOS.
+- [react-native-triangle ★69](https://github.com/Jpoliachik/react-native-triangle) - draw triangle views in react native
+- [react-native-tween-animation ★40](https://github.com/kirkness/react-native-tween-animation) - A simple react native state tween animation module.
+- [react-native-ui-kitten ★1865](https://github.com/akveo/react-native-ui-kitten) - Customizable and reusable react-native component kit
+- [react-native-vector-icons ★6677](https://github.com/oblador/react-native-vector-icons) - Customizable Icons for React Native with support for NavBar/TabBar, image source and full styling. Choose from 3000+ bundled icons or use your own.
+- [react-native-view ★30](https://github.com/i6mi6/react-native-view) - Lightweight View component for quick styling.
+- [react-native-viewpager ★1208](https://github.com/race604/react-native-viewpager) - ViewPager component for React Native
+- [react-native-viewport-units ★71](https://github.com/jmstout/react-native-viewport-units) - Incredibly simple utility for (sort of) using viewport units with React Native.
 - [react-native-viewport ★42](https://github.com/pjjanak/react-native-viewport) - Viewport dimensions for react-native
-- [react-native-webbrowser ★80](https://github.com/d-a-n/react-native-webbrowser) - A cross-platform (iOS / Android), full-featured, highly customizable web browser module for React Native apps.
-- [react-native-android-wheel-picker ★15](https://github.com/ElekenAgency/ReactNativeWheelPicker) - Simple and flexible React native wheel picker for Android, including DatePicker and TimePicker.
-- [react-native-wheel-picker ★52](https://github.com/lesliesam/react-native-wheel-picker) - React native cross platform picker.
-- [react-native-wheel ★20](https://github.com/shexiaoheng/react-native-wheel) - android wheel view for react-native
-- [react-native-writebox ★1](https://github.com/bdryanovski/react-native-writebox) - (iOS / Android) Facebook/Twitter textarea that autogrow and count characters.
-- [react-native-message-bar ★182](https://github.com/KBLNY/react-native-message-bar) - A module for presenting notifications via an animated message bar at the top/bottom of the screen, highly customizable, for React Native (Android and iOS) projects.
-- [react-native-sglistview ★514](https://github.com/sghiassy/react-native-sglistview) - A memory minded implementation of React Native's ListView
-- [react-router-native ★456](https://github.com/jmurzy/react-router-native) - A routing library for React Native that strives for sensible API parity with [React Router](https://github.com/reactjs/react-router)
-- [react-native-telephone-input ★19](https://github.com/kundigo/react-native-telephone-input) - React Native Telephone Input, discover country and mask telephone Input
-- [react-native-off-canvas-menu ★159](https://github.com/shoumma/react-native-off-canvas-menu) - Beautifully crafted off canvas menu components for react native applications.
-- [react-native-progressive-input ★25](https://github.com/khaiql/react-native-progressive-input) - TextInput with clear button and activity indicator, used as part of autocomplete list.
-- [react-native-image-carousel ★34](https://github.com/anvilabs/react-native-image-carousel) - Image carousel with support for fullscreen mode, image swiping and pinch-to-zoom in fullscreen mode.
-- [react-native-popup-menu ★116](https://github.com/instea/react-native-popup-menu) - Extensible popup menu component for React Native.
-- [react-native-color-picker ★49](https://github.com/instea/react-native-color-picker) - React Native implementation of color picker for both Android and iOS.
-- [react-native-step-indicator ★62](https://github.com/24ark/react-native-step-indicator) - A simple react-native implementation of step indicator widget compatible with the ViewPager and ListView.
-- [nachos-ui ★996](https://github.com/avocode/nachos-ui) - NACHOS UI kit for React Native. Pick from a bunch of pre-coded UI components ready for your next kick-ass app in JavaScript or React.
-- [lottie-react-native ★4537](https://github.com/airbnb/lottie-react-native) - a mobile library for Android and iOS that parses Adobe After Effects animations exported as JSON with bodymovin and renders them natively on mobile!
-- [react-native-animatable ★2069](https://github.com/oblador/react-native-animatable) - Standard set of easy to use animations and declarative transitions for React Native (built on react-native Animated
-- [react-native-snackbar-component ★0](https://github.com/SiDevesh/React-Native-SnackBar-Component) - A snackbar component for Android and iOS, customizable and simple.
-- [react-native-expand ★3](https://github.com/hejiaji/react-native-expand) - A react-native expandable component for both Android and iOS
-- [react-native-zoom-image ★8](https://github.com/Tinysymphony/react-native-zoom-image) - An image viewer component for react-native, like twitter's image viewer.
-- [react-native-hijri-date-picker](https://github.com/Codelabsys/react-native-hijri-date-picker-android) -  Date Picker Dialog for Hijri calendar for android.
-- [react-native-md-motion-buttons](https://github.com/zecaptus/react-native-md-motion-buttons) - Material design motion button inspired by inVision app.
-- [react-native-fab](https://github.com/SiDevesh/React-Native-FAB) - A FAB button component for Android and iOS, customizable, simple and as per material design specs.
-- [react-native-material-cards](https://github.com/SiDevesh/React-Native-Material-Cards) - A material design card component, customizable and versatile.
-- [react-native-comparison-slider](https://github.com/charlot567/react-native-comparison-slider) - A simple component to display two image in comparison with a slide-over feature.
-- [react-native-submit-button ★64](https://github.com/ronak301/react-native-submit-button) - Animated Submit button. Works on both android and ios.
-- [react-native-3dcube-navigation ★8](https://github.com/zehfernandes/react-native-3dcube-navigation) - Page Swiper component with 3D cube transition (horizontal and vertical)
-- [react-native-switch-selector](https://github.com/App2Sales/react-native-switch-selector) - A custom Switch Selector component for Android and iOS.
-- [react-native-taptargetview](https://github.com/prscX/react-native-taptargetview) - React Native Bridge for Android KeepSafe/TapTargetView. An implementation of tap targets from the Material Design guidelines for feature discovery.
-- [react-native-material-showcase-ios](https://github.com/prscX/react-native-material-showcase-ios) - React Native Bridge for iOS aromajoin/material-showcase-ios. An elegant and beautiful showcase for iOS apps.
+- [react-native-webbrowser ★128](https://github.com/d-a-n/react-native-webbrowser) - A cross-platform (iOS / Android), full-featured, highly customizable web browser module for React Native apps.
+- [react-native-android-wheel-picker ★54](https://github.com/ElekenAgency/ReactNativeWheelPicker) - Simple and flexible React native wheel picker for Android, including DatePicker and TimePicker.
+- [react-native-wheel-picker ★105](https://github.com/lesliesam/react-native-wheel-picker) - React native cross platform picker.
+- [react-native-wheel ★25](https://github.com/shexiaoheng/react-native-wheel) - android wheel view for react-native
+- [react-native-writebox ★20](https://github.com/bdryanovski/react-native-writebox) - (iOS / Android) Facebook/Twitter textarea that autogrow and count characters.
+- [react-native-message-bar ★300](https://github.com/KBLNY/react-native-message-bar) - A module for presenting notifications via an animated message bar at the top/bottom of the screen, highly customizable, for React Native (Android and iOS) projects.
+- [react-native-sglistview ★665](https://github.com/sghiassy/react-native-sglistview) - A memory minded implementation of React Native's ListView
+- [react-router-native ★572](https://github.com/jmurzy/react-router-native) - A routing library for React Native that strives for sensible API parity with [React Router](https://github.com/reactjs/react-router)
+- [react-native-telephone-input ★26](https://github.com/kundigo/react-native-telephone-input) - React Native Telephone Input, discover country and mask telephone Input
+- [react-native-off-canvas-menu ★239](https://github.com/shoumma/react-native-off-canvas-menu) - Beautifully crafted off canvas menu components for react native applications.
+- [react-native-progressive-input ★61](https://github.com/khaiql/react-native-progressive-input) - TextInput with clear button and activity indicator, used as part of autocomplete list.
+- [react-native-image-carousel ★92](https://github.com/anvilabs/react-native-image-carousel) - Image carousel with support for fullscreen mode, image swiping and pinch-to-zoom in fullscreen mode.
+- [react-native-popup-menu ★334](https://github.com/instea/react-native-popup-menu) - Extensible popup menu component for React Native.
+- [react-native-color-picker ★108](https://github.com/instea/react-native-color-picker) - React Native implementation of color picker for both Android and iOS.
+- [react-native-step-indicator ★282](https://github.com/24ark/react-native-step-indicator) - A simple react-native implementation of step indicator widget compatible with the ViewPager and ListView.
+- [nachos-ui ★1329](https://github.com/avocode/nachos-ui) - NACHOS UI kit for React Native. Pick from a bunch of pre-coded UI components ready for your next kick-ass app in JavaScript or React.
+- [lottie-react-native ★7448](https://github.com/airbnb/lottie-react-native) - a mobile library for Android and iOS that parses Adobe After Effects animations exported as JSON with bodymovin and renders them natively on mobile!
+- [react-native-animatable ★3841](https://github.com/oblador/react-native-animatable) - Standard set of easy to use animations and declarative transitions for React Native (built on react-native Animated
+- [react-native-snackbar-component ★44](https://github.com/SiDevesh/React-Native-SnackBar-Component) - A snackbar component for Android and iOS, customizable and simple.
+- [react-native-expand ★13](https://github.com/hejiaji/react-native-expand) - A react-native expandable component for both Android and iOS
+- [react-native-zoom-image ★41](https://github.com/Tinysymphony/react-native-zoom-image) - An image viewer component for react-native, like twitter's image viewer.
+- [react-native-hijri-date-picker ★10](https://github.com/Codelabsys/react-native-hijri-date-picker-android) -  Date Picker Dialog for Hijri calendar for android.
+- [react-native-md-motion-buttons ★27](https://github.com/zecaptus/react-native-md-motion-buttons) - Material design motion button inspired by inVision app.
+- [react-native-fab ★20](https://github.com/SiDevesh/React-Native-FAB) - A FAB button component for Android and iOS, customizable, simple and as per material design specs.
+- [react-native-material-cards ★32](https://github.com/SiDevesh/React-Native-Material-Cards) - A material design card component, customizable and versatile.
+- [react-native-comparison-slider ★8](https://github.com/charlot567/react-native-comparison-slider) - A simple component to display two image in comparison with a slide-over feature.
+- [react-native-submit-button ★74](https://github.com/ronak301/react-native-submit-button) - Animated Submit button. Works on both android and ios.
+- [react-native-3dcube-navigation ★30](https://github.com/zehfernandes/react-native-3dcube-navigation) - Page Swiper component with 3D cube transition (horizontal and vertical)
+- [react-native-switch-selector ★20](https://github.com/App2Sales/react-native-switch-selector) - A custom Switch Selector component for Android and iOS.
+- [react-native-taptargetview ★25](https://github.com/prscX/react-native-taptargetview) - React Native Bridge for Android KeepSafe/TapTargetView. An implementation of tap targets from the Material Design guidelines for feature discovery.
+- [react-native-material-showcase-ios ★18](https://github.com/prscX/react-native-material-showcase-ios) - React Native Bridge for iOS aromajoin/material-showcase-ios. An elegant and beautiful showcase for iOS apps.
 
 
 ### Navigation
-- [native-navigation ★1237](https://github.com/airbnb/native-navigation) - Native navigation library for React Native applications
-- [react-navigation ★2586](https://github.com/react-community/react-navigation) - Easy to use Navigation for React Native
-- [react-native-ya-navigator ★66](https://github.com/xxsnakerxx/react-native-ya-navigator) - Yet another react native navigator component
-- [react-native-route-navigator ★26](https://github.com/Andr3wHur5t/react-native-route-navigator) - React-Native page navigation using URIs.
-- [react-native-router ★1144](https://github.com/t4t5/react-native-router) - Awesome navigation for your native app.
-- [react-native-controllers ★443](https://github.com/wix/react-native-controllers) - Truly native no-compromise iOS navigation for React Native.
-- [react-native-navigation ★2121](https://github.com/wix/react-native-navigation) - App-wide support for 100% native navigation with an easy cross-platform interface.
-- [react-native-url-handler ★33](https://github.com/exponentjs/react-native-url-handler) - Navigate to external URLs, handle in-app URLs, and access system URLs
-- [ex-navigation ★813](https://github.com/exponentjs/ex-navigation) - A route-centric, batteries-included navigation library for Exponent and React Native that works seamlessly on Android and iOS.
-- [ex-navigator ★508](https://github.com/exponentjs/ex-navigator) - Route-centric navigation built on top of React Native's Navigator
-- [navbar-native ★62](https://github.com/redbaron76/navbar-native) - A new, fully customizable Navbar component for React-Native
+- [native-navigation ★2621](https://github.com/airbnb/native-navigation) - Native navigation library for React Native applications
+- [react-navigation ★8319](https://github.com/react-community/react-navigation) - Easy to use Navigation for React Native
+- [react-native-ya-navigator ★89](https://github.com/xxsnakerxx/react-native-ya-navigator) - Yet another react native navigator component
+- [react-native-route-navigator ★27](https://github.com/Andr3wHur5t/react-native-route-navigator) - React-Native page navigation using URIs.
+- [react-native-router ★1195](https://github.com/t4t5/react-native-router) - Awesome navigation for your native app.
+- [react-native-controllers ★523](https://github.com/wix/react-native-controllers) - Truly native no-compromise iOS navigation for React Native.
+- [react-native-navigation ★5429](https://github.com/wix/react-native-navigation) - App-wide support for 100% native navigation with an easy cross-platform interface.
+- [react-native-url-handler ★34](https://github.com/exponentjs/react-native-url-handler) - Navigate to external URLs, handle in-app URLs, and access system URLs
+- [ex-navigation ★984](https://github.com/exponentjs/ex-navigation) - A route-centric, batteries-included navigation library for Exponent and React Native that works seamlessly on Android and iOS.
+- [ex-navigator ★526](https://github.com/exponentjs/ex-navigator) - Route-centric navigation built on top of React Native's Navigator
+- [navbar-native ★79](https://github.com/redbaron76/navbar-native) - A new, fully customizable Navbar component for React-Native
 - [react-native-router-sinux ★ ★3](https://github.com/jbpin/react-native-router-sinux) - React Native Router based on new NavigationExperimental that use Sinux as Flux implementation.
-- [react-native-router-flux ★3683](https://github.com/aksonov/react-native-router-flux) - React Native Router based on new React Native Navigation API
-- [react-native-nav ★186](https://github.com/jineshshah36/react-native-nav) - A cross-platform (iOS / Android), fully customizable, React Native Navigation Bar component
-- [react-native-navbar ★1406](https://github.com/Kureev/react-native-navbar) - Simple customizable navbar component for react-native
-- [react-native-navigation-bar ★51](https://github.com/beefe/react-native-navigation-bar) - react-native-navigation-bar
+- [react-native-router-flux ★5909](https://github.com/aksonov/react-native-router-flux) - React Native Router based on new React Native Navigation API
+- [react-native-nav ★232](https://github.com/jineshshah36/react-native-nav) - A cross-platform (iOS / Android), fully customizable, React Native Navigation Bar component
+- [react-native-navbar ★1682](https://github.com/Kureev/react-native-navbar) - Simple customizable navbar component for react-native
+- [react-native-navigation-bar ★56](https://github.com/beefe/react-native-navigation-bar) - react-native-navigation-bar
 - [react-native-navigation-buttons ★2](https://github.com/shayne/react-native-navigation-buttons) - iOS navigation buttons for the React Native Navigator
-- [react-native-navigation-drawer ★70](https://github.com/ilansas/react-native-navigation-drawer) - A slide menu inspired from Android for React-Native
-- [react-native-navigator ★72](https://github.com/thewei/react-native-navigator) - A simple router for react native
+- [react-native-navigation-drawer ★86](https://github.com/ilansas/react-native-navigation-drawer) - A slide menu inspired from Android for React-Native
+- [react-native-navigator ★76](https://github.com/thewei/react-native-navigator) - A simple router for react native
 - [react-native-yynavigator ★0](https://github.com/yiyangest/react-native-yynavigator) - custom navigation bar for react-native
-- [react-native-transparent-bar ★13](https://github.com/23c/react-native-transparent-bar) - react native navigator transparent bar
-- [kittenTricks ★700](https://github.com/akveo/kittenTricks) - A react native mobile starter kit with over 40 screens and theme hot reload support
-- [react-native-grid-list ★](https://github.com/gusgard/react-native-grid-list) - React Native Grid List component
+- [react-native-transparent-bar ★16](https://github.com/23c/react-native-transparent-bar) - react native navigator transparent bar
+- [kittenTricks ★3086](https://github.com/akveo/kittenTricks) - A react native mobile starter kit with over 40 screens and theme hot reload support
+- [react-native-grid-list ★ ★3](https://github.com/gusgard/react-native-grid-list) - React Native Grid List component
 
 #### Navigation/Routing Articles
 - [Basics of using react-native-router-flux](https://medium.com/@spencer_carli/react-native-basics-using-react-native-router-flux-f11e5128aff9#.di5mvrbdr)
@@ -516,524 +516,522 @@ Components and native modules. For more search [JS.COACH](https://js.coach/react
 - [NavigatorIOS: Accessing onRightButtonPress from within child component](https://github.com/facebook/react-native/issues/31)
 
 #### Navigation Demos
-- [ExNavRelay ★18](https://github.com/sibelius/ExNavRelay) - React Native + Ex-navigation + Relay integration template
-- [movieapp ★273](https://github.com/JuneDomingo/movieapp) – Discover Movies and TV shows - it uses redux and wix/react-native-navigation
-- [Navigator Demo ★167](https://github.com/h87kg/NavigatorDemo)
+- [ExNavRelay ★20](https://github.com/sibelius/ExNavRelay) - React Native + Ex-navigation + Relay integration template
+- [movieapp ★913](https://github.com/JuneDomingo/movieapp) – Discover Movies and TV shows - it uses redux and wix/react-native-navigation
+- [Navigator Demo ★188](https://github.com/h87kg/NavigatorDemo)
 - [React Native Example App: Navigation](http://tech.taskrabbit.com/blog/2015/09/21/react-native-example-app/)
 
 ### Text & Rich Content
 
 - [react-native-asciimage ★16](https://github.com/turley/react-native-asciimage) - An ASCIImage component for React Native
-- [react-native-draftjs-render ★6](https://github.com/globocom/react-native-draftjs-render) - A React Native render for Draft.js model
-- [react-native-html-render ★74](https://github.com/soliury/react-native-html-render) - A html render for react-native
-- [react-native-html-to-pdf ★65](https://github.com/christopherdro/react-native-html-to-pdf) - Convert html strings to PDF documents using React Native
-- [react-native-html-webview ★90](https://github.com/almost/react-native-html-webview) - Display (possibly untrusted) HTML using a UIWebView in React Native.
-- [react-native-html ★9](https://github.com/turingou/react-native-html) - render html as react native custom elements
-- [react-native-htmltext ★90](https://github.com/siuying/react-native-htmltext) - Use HTML like markup to create stylized text in react-native.
-- [react-native-hypertext ★19](https://github.com/agentcooper/react-native-hypertext) - React Native module to render hypertext (text with links)
-- [react-native-universal-modal ★13](https://github.com/bokuweb/react-native-universal-modal) - Universal simple modal component for React Native
-- [react-native-hyperlink ★67](https://github.com/obipawan/hyperlink) - A `<Hyperlink />` component for react-native that makes urls, fuzzy links, emails etc clickable and stylable
-- [react-native-measure-text ★6](https://github.com/airamrguez/react-native-measure-text) - Measure text height without laying it out.
+- [react-native-draftjs-render ★157](https://github.com/globocom/react-native-draftjs-render) - A React Native render for Draft.js model
+- [react-native-html-render ★93](https://github.com/soliury/react-native-html-render) - A html render for react-native
+- [react-native-html-to-pdf ★113](https://github.com/christopherdro/react-native-html-to-pdf) - Convert html strings to PDF documents using React Native
+- [react-native-html-webview ★97](https://github.com/almost/react-native-html-webview) - Display (possibly untrusted) HTML using a UIWebView in React Native.
+- [react-native-html ★11](https://github.com/turingou/react-native-html) - render html as react native custom elements
+- [react-native-htmltext ★118](https://github.com/siuying/react-native-htmltext) - Use HTML like markup to create stylized text in react-native.
+- [react-native-hypertext ★21](https://github.com/agentcooper/react-native-hypertext) - React Native module to render hypertext (text with links)
+- [react-native-universal-modal ★16](https://github.com/bokuweb/react-native-universal-modal) - Universal simple modal component for React Native
+- [react-native-hyperlink ★173](https://github.com/obipawan/hyperlink) - A `<Hyperlink />` component for react-native that makes urls, fuzzy links, emails etc clickable and stylable
+- [react-native-measure-text ★16](https://github.com/airamrguez/react-native-measure-text) - Measure text height without laying it out.
 
 ### Analytics
 
-- [react-native-ab ★110](https://github.com/lwansbrough/react-native-ab) - A component for rendering A/B tests in React Native
-- [react-native-google-analytics ★196](https://github.com/lwansbrough/react-native-google-analytics) - Google Analytics for React Native!
-- [react-native-fabric ★476](https://github.com/corymsmith/react-native-fabric) - A React Native library for Fabric, Crashlytics and Answers
-- [react-native-mixpanel ★123](https://github.com/davodesign84/react-native-mixpanel) - A React Native wrapper for Mixpanel tracking
-- [react-native-segment-io-analytics ★44](https://github.com/smore-inc/react-native-segment-io-analytics) - A React Native Segment wrapper!
-- [react-native-google-analytics-bridge ★389](https://github.com/idehub/react-native-google-analytics-bridge) - A native Google Analytics bridge for React Native. Uses the official libraries on both iOS and Android.
-- [react-native-ux-cam ★11](https://github.com/negativetwelve/react-native-ux-cam) - React Native wrapper for uxcam.com.
+- [react-native-ab ★137](https://github.com/lwansbrough/react-native-ab) - A component for rendering A/B tests in React Native
+- [react-native-google-analytics ★245](https://github.com/lwansbrough/react-native-google-analytics) - Google Analytics for React Native!
+- [react-native-fabric ★777](https://github.com/corymsmith/react-native-fabric) - A React Native library for Fabric, Crashlytics and Answers
+- [react-native-mixpanel ★211](https://github.com/davodesign84/react-native-mixpanel) - A React Native wrapper for Mixpanel tracking
+- [react-native-segment-io-analytics ★62](https://github.com/smore-inc/react-native-segment-io-analytics) - A React Native Segment wrapper!
+- [react-native-google-analytics-bridge ★767](https://github.com/idehub/react-native-google-analytics-bridge) - A native Google Analytics bridge for React Native. Uses the official libraries on both iOS and Android.
+- [react-native-ux-cam ★13](https://github.com/negativetwelve/react-native-ux-cam) - React Native wrapper for uxcam.com.
 
 ### Utils & Infra
 
 - [react-native-HsvToRgb ★2](https://github.com/Copypeng/react-native-HsvToRgb) - a helper to convert HSV(HSB) color to RGB.
-- [react-native-call-detection ★40](https://github.com/priteshrnandgaonkar/react-native-call-detection) - Helps to detect different call states like Incoming, Disconnected, Dialing and Connected 
-- [react-native-simple-encryption ★9](https://github.com/BhavanPatel/react-native-simple-encryption) - Simple XOR and base_64 encryption decryption for react-native
-- [react-native-aes ★15](https://github.com/mvayngrib/react-native-aes) - AES in react-native
-- [react-native-aws-signature ★33](https://github.com/leimd/react-native-aws-signature) - help generate signature required for using AWS API. Necessary to use S3, ec2, or other services.
-- [react-native-babel-jest ★10](https://github.com/apentle/react-native-babel-jest) - Simple testing configuration for React Native with Jest
-- [react-native-crypto ★54](https://github.com/mvayngrib/react-native-crypto) - implementation of crypto for React Native
-- [react-native-des ★13](https://github.com/remobile/react-native-des) - A des crypto for react-native
-- [react-native-device-log ★29](https://github.com/olofd/react-native-device-log) - A UI and service for displaying dev-logs on devices.
-- [react-native-eval ★51](https://github.com/artemyarulin/react-native-eval) - Call any JS functions from your native code
+- [react-native-call-detection ★40](https://github.com/priteshrnandgaonkar/react-native-call-detection) - Helps to detect different call states like Incoming, Disconnected, Dialing and Connected
+- [react-native-simple-encryption ★11](https://github.com/BhavanPatel/react-native-simple-encryption) - Simple XOR and base_64 encryption decryption for react-native
+- [react-native-aes ★21](https://github.com/mvayngrib/react-native-aes) - AES in react-native
+- [react-native-aws-signature ★38](https://github.com/leimd/react-native-aws-signature) - help generate signature required for using AWS API. Necessary to use S3, ec2, or other services.
+- [react-native-babel-jest ★13](https://github.com/apentle/react-native-babel-jest) - Simple testing configuration for React Native with Jest
+- [react-native-crypto ★115](https://github.com/mvayngrib/react-native-crypto) - implementation of crypto for React Native
+- [react-native-des ★15](https://github.com/remobile/react-native-des) - A des crypto for react-native
+- [react-native-device-log ★46](https://github.com/olofd/react-native-device-log) - A UI and service for displaying dev-logs on devices.
+- [react-native-eval ★64](https://github.com/artemyarulin/react-native-eval) - Call any JS functions from your native code
 - [react-native-fluxbone ★5](https://github.com/jgable/react-native-fluxbone) - A group of libraries that help with the FluxBone pattern in React Native
-- [react-native-global-event-emitter ★36](https://github.com/paramaggarwal/react-native-global-event-emitter) - Shared event emitter between native and JS for React Native.
-- [react-native-immutable ★11](https://github.com/thewei/react-native-immutable) - using immutable.js library with react-native
-- [react-native-mock ★313](https://github.com/RealOrangeOne/react-native-mock) - A fully mocked and test-friendly version of react native
-- [react-native-rsa ★8](https://github.com/z-hao-wang/react-native-rsa) - RSA crypto lib for react native
+- [react-native-global-event-emitter ★43](https://github.com/paramaggarwal/react-native-global-event-emitter) - Shared event emitter between native and JS for React Native.
+- [react-native-immutable ★12](https://github.com/thewei/react-native-immutable) - using immutable.js library with react-native
+- [react-native-mock ★425](https://github.com/RealOrangeOne/react-native-mock) - A fully mocked and test-friendly version of react native
+- [react-native-rsa ★22](https://github.com/z-hao-wang/react-native-rsa) - RSA crypto lib for react native
 - [react-native-tools ★0](https://github.com/kkennis/react-native-tools) - Tools for react native project development
-- [react-native-user-defaults ★32](https://github.com/wwayne/react-native-user-defaults) - ios UserDefaults used by react-native
-- [react-native-userdefaults-ios ★53](https://github.com/dsibiski/react-native-userdefaults-ios) - React Native Module for NSUserDefaults
-- [react-native-util ★8](https://github.com/exponentjs/react-native-util) - A fork of io.js's util module that works with React Native
-- [react-native-webp ★29](https://github.com/dbasedow/react-native-webp) - react-native-webp adds support for WebP images for react-native components.
-- [react-native-webpackager-server ★2](https://github.com/changfuguo/react-native-webpackager-server) - react native webpackager server
-- [react-native-zip-archive ★49](https://github.com/plrthink/react-native-zip-archive) - Zip / Unzip archive utility
-- [react-native-html-parser ★10](https://github.com/g6ling/react-native-html-parser) - parse html in react-native
-- [react-native-slowlog ★55](https://github.com/jondot/react-native-slowlog) - A high-performance timer based profiler for React Native that helps you track big performance problems
-- [codemod-RN24-to-RN25 ★94](https://github.com/sibeliusseraphini/codemod-RN24-to-RN25) - a simple codemod to handle the new import style on >=RN25
-- [react-native-workers ★291](https://github.com/devfd/react-native-workers) - Background services and web workers for react-native
-- [react-native-console-time-polyfill ★2](https://github.com/MaxGraey/react-native-console-time-polyfill) - console.time and console.timeEnd polyfill for react-native
-- [detox ★422](https://github.com/wix/detox) - Graybox End-to-End (functional) Tests and Automation Library for Mobile with first class support for React Native
-- [react-native-linkedin ★24](https://github.com/xcarpentier/react-native-linkedin) React-Native LinkedIn, a simple LinkedIn login library for React-Native or Expo with WebView and Modal
+- [react-native-user-defaults ★47](https://github.com/wwayne/react-native-user-defaults) - ios UserDefaults used by react-native
+- [react-native-userdefaults-ios ★59](https://github.com/dsibiski/react-native-userdefaults-ios) - React Native Module for NSUserDefaults
+- [react-native-util ★10](https://github.com/exponentjs/react-native-util) - A fork of io.js's util module that works with React Native
+- [react-native-webp ★46](https://github.com/dbasedow/react-native-webp) - react-native-webp adds support for WebP images for react-native components.
+- [react-native-webpackager-server ★5](https://github.com/changfuguo/react-native-webpackager-server) - react native webpackager server
+- [react-native-zip-archive ★106](https://github.com/plrthink/react-native-zip-archive) - Zip / Unzip archive utility
+- [react-native-html-parser ★26](https://github.com/g6ling/react-native-html-parser) - parse html in react-native
+- [react-native-slowlog ★93](https://github.com/jondot/react-native-slowlog) - A high-performance timer based profiler for React Native that helps you track big performance problems
+- [codemod-RN24-to-RN25 ★100](https://github.com/sibeliusseraphini/codemod-RN24-to-RN25) - a simple codemod to handle the new import style on >=RN25
+- [react-native-workers ★458](https://github.com/devfd/react-native-workers) - Background services and web workers for react-native
+- [react-native-console-time-polyfill ★16](https://github.com/MaxGraey/react-native-console-time-polyfill) - console.time and console.timeEnd polyfill for react-native
+- [detox ★1511](https://github.com/wix/detox) - Graybox End-to-End (functional) Tests and Automation Library for Mobile with first class support for React Native
+- [react-native-linkedin ★42](https://github.com/xcarpentier/react-native-linkedin) React-Native LinkedIn, a simple LinkedIn login library for React-Native or Expo with WebView and Modal
 
 ### Forms
 
-- [react-native-clean-form ★118](https://github.com/esbenp/react-native-clean-form) - Good looking form elements with redux-form integration. Stylable with styled-components.
-- [react-native-fm-form ★10](https://github.com/peter4k/react-native-fm-form) - Generate list view form of React Native in few line of codes
+- [react-native-clean-form ★315](https://github.com/esbenp/react-native-clean-form) - Good looking form elements with redux-form integration. Stylable with styled-components.
+- [react-native-fm-form ★13](https://github.com/peter4k/react-native-fm-form) - Generate list view form of React Native in few line of codes
 - [react-native-form-flux ★2](https://github.com/aksonov/react-native-form-flux) - React Native Form management using Flux architecture
-- [react-native-form ★100](https://github.com/julianocomg/react-native-form) - A simple react-native component to wrap your form fields!
-- [react-native-forms ★50](https://github.com/michaelhelvey/react-native-forms) - A declarative API for creating, validating, and serializing native-looking forms.
-- [react-native-form-generator ★207](https://github.com/MichaelCereda/react-native-form-generator) - Generate amazing React Native forms in a breeze
-- [react-native-gifted-form ★699](https://github.com/FaridSafi/react-native-gifted-form) - Form component for react-native
+- [react-native-form ★127](https://github.com/julianocomg/react-native-form) - A simple react-native component to wrap your form fields!
+- [react-native-forms ★78](https://github.com/michaelhelvey/react-native-forms) - A declarative API for creating, validating, and serializing native-looking forms.
+- [react-native-form-generator ★312](https://github.com/MichaelCereda/react-native-form-generator) - Generate amazing React Native forms in a breeze
+- [react-native-gifted-form ★1052](https://github.com/FaridSafi/react-native-gifted-form) - Form component for react-native
 - [redux-form ★4829](http://redux-form.com) - Redux form state management (Web and Native)
-- [tcomb-form-native ★1657](https://github.com/gcanti/tcomb-form-native) - Generate React Native forms
-- [foect ★4](https://github.com/unexge/foect) - Simple form validation library for React Native
-- [formik ★2270](https://github.com/jaredpalmer/formik) - Forms in React, without tears.
+- [tcomb-form-native ★2293](https://github.com/gcanti/tcomb-form-native) - Generate React Native forms
+- [foect ★28](https://github.com/unexge/foect) - Simple form validation library for React Native
+- [formik ★3822](https://github.com/jaredpalmer/formik) - Forms in React, without tears.
 
 ### Geolocation
 
-- [react-native-background-geolocation ★770](https://github.com/transistorsoft/react-native-background-geolocation) - Sophisticated cross-platform background location-tracking & geofencing module with battery-conscious motion-detection intelligence (Android requires  paid license).
-- [react-native-android-geolocation ★17](https://github.com/garysye/react-native-android-geolocation) - React Native Module to use Android Geolocation via Google Play API
+- [react-native-background-geolocation ★826](https://github.com/transistorsoft/react-native-background-geolocation) - Sophisticated cross-platform background location-tracking & geofencing module with battery-conscious motion-detection intelligence (Android requires  paid license).
+- [react-native-android-geolocation ★18](https://github.com/garysye/react-native-android-geolocation) - React Native Module to use Android Geolocation via Google Play API
 - [react-native-geolocation-android ★3](https://github.com/lxsameer/react-native-geolocation-android) - Geolocation module for react native android
-- [react-native-geocoder ★152](https://github.com/devfd/react-native-geocoder) - react native geocoding and reverse geocoding
-- [react-native-mauron85-background-geolocation ★290](https://github.com/mauron85/react-native-background-geolocation) - React Native Android and iOS module for background and foreground geolocation with battery-saving "circular region monitoring" and "stop detection"
-- [react-native-reverse-geo ★14](https://github.com/aaronksaunders/react-native-reverse-geo) - React Native module bridge to convert address to geo coordinates.
-- [react-native-geo-fencing ★40](https://github.com/surialabs/react-native-geo-fencing) - Native modules to determine if a location is within defined geographical boundaries using Google Geometry library
-- [react-native-fused-location ★31](https://github.com/MustansirZia/react-native-fused-location) - Finest location for react-native on Android using the new Fused API.
+- [react-native-geocoder ★266](https://github.com/devfd/react-native-geocoder) - react native geocoding and reverse geocoding
+- [react-native-mauron85-background-geolocation ★302](https://github.com/mauron85/react-native-background-geolocation) - React Native Android and iOS module for background and foreground geolocation with battery-saving "circular region monitoring" and "stop detection"
+- [react-native-reverse-geo ★16](https://github.com/aaronksaunders/react-native-reverse-geo) - React Native module bridge to convert address to geo coordinates.
+- [react-native-geo-fencing ★68](https://github.com/surialabs/react-native-geo-fencing) - Native modules to determine if a location is within defined geographical boundaries using Google Geometry library
+- [react-native-fused-location ★33](https://github.com/MustansirZia/react-native-fused-location) - Finest location for react-native on Android using the new Fused API.
 
 ### Internationalization
 
-- [react-native-globalize ★61](https://github.com/joshswan/react-native-globalize) - Globalization helper for React Native
-- [react-native-i18n ★516](https://github.com/AlexanderZaytsev/react-native-i18n) - React Native + i18n.js
-- [rn-translate-template ★11](https://github.com/hiaw/rn-translate-template) - I18n template for all iOS and Android supported languages
-- [react-native-intl ★21](https://github.com/taggon/react-native-intl) - React Native module shipped native Intl implementation and Translation extension
-- [redux-react-native-i18n ★6](https://github.com/derzunov/redux-react-native-i18n) - An i18n solution for React Native apps on Redux
-- [react-native-languages ★18](https://github.com/react-community/react-native-languages) - React Native properties and methods related to the language of the device
+- [react-native-globalize ★134](https://github.com/joshswan/react-native-globalize) - Globalization helper for React Native
+- [react-native-i18n ★1051](https://github.com/AlexanderZaytsev/react-native-i18n) - React Native + i18n.js
+- [rn-translate-template ★15](https://github.com/hiaw/rn-translate-template) - I18n template for all iOS and Android supported languages
+- [react-native-intl ★31](https://github.com/taggon/react-native-intl) - React Native module shipped native Intl implementation and Translation extension
+- [redux-react-native-i18n ★23](https://github.com/derzunov/redux-react-native-i18n) - An i18n solution for React Native apps on Redux
+- [react-native-languages ★47](https://github.com/react-community/react-native-languages) - React Native properties and methods related to the language of the device
 
 ### Build & Development
 
-- [react-native-assets ★29](https://github.com/llanox/react-native-assests) - Module to manage assets. It allows you download assets from a network and store into a specific local folder on iOS
-- [babel-preset-react-native-stage-0 ★53](https://github.com/skevy/babel-preset-react-native-stage-0) - a Babel preset with latest Javascript goodies
+- [react-native-assets ★30](https://github.com/llanox/react-native-assests) - Module to manage assets. It allows you download assets from a network and store into a specific local folder on iOS
+- [babel-preset-react-native-stage-0 ★80](https://github.com/skevy/babel-preset-react-native-stage-0) - a Babel preset with latest Javascript goodies
 - [react-native-build-cli ★3](https://github.com/adonpro/react-native-build-cli) - a cli tool for react-native build
-- [react-native-code-push ★2469](https://github.com/Microsoft/react-native-code-push) - React Native plugin for the CodePush service
-- [react-native-console-panel ★56](https://github.com/sospartan/react-native-console-panel) - react native component for display console messages.
-- [react-native-cosmos ★17](https://github.com/jerolimov/react-native-cosmos) - DX tool to test react-native components with defined props/state fixtures.
-- [react-native-css-loader ★30](https://github.com/thewei/react-native-css-loader) - You can use react-native-css-loader with react-native-webpack-server, which can use webpack to built react-native app better.
-- [react-native-debug-stylesheet ★58](https://github.com/brentvatne/react-native-debug-stylesheet) - Add coloured borders or backgrounds to all views to make it easier to debug layout issues
-- [react-native-kill-packager ★4](https://github.com/livioso/react-native-kill-packager) - kill running react native packager.
-- [react-native-webpack-server ★862](https://github.com/mjohnston/react-native-webpack-server) - Build React Native apps with Webpack
-- [reactotron ★5318](https://github.com/skellock/reactotron) - Control, monitor, and instrument your React Native apps from the comfort of your terminal.
-- [generator-rn-toolbox ★99](https://github.com/bamlab/generator-rn-toolbox) - Yeoman generators to kickstart your project and setup continuous deployment.
+- [react-native-code-push ★3811](https://github.com/Microsoft/react-native-code-push) - React Native plugin for the CodePush service
+- [react-native-console-panel ★60](https://github.com/sospartan/react-native-console-panel) - react native component for display console messages.
+- [react-native-cosmos ★16](https://github.com/jerolimov/react-native-cosmos) - DX tool to test react-native components with defined props/state fixtures.
+- [react-native-css-loader ★35](https://github.com/thewei/react-native-css-loader) - You can use react-native-css-loader with react-native-webpack-server, which can use webpack to built react-native app better.
+- [react-native-debug-stylesheet ★65](https://github.com/brentvatne/react-native-debug-stylesheet) - Add coloured borders or backgrounds to all views to make it easier to debug layout issues
+- [react-native-kill-packager ★9](https://github.com/livioso/react-native-kill-packager) - kill running react native packager.
+- [react-native-webpack-server ★905](https://github.com/mjohnston/react-native-webpack-server) - Build React Native apps with Webpack
+- [reactotron ★7080](https://github.com/skellock/reactotron) - Control, monitor, and instrument your React Native apps from the comfort of your terminal.
+- [generator-rn-toolbox ★421](https://github.com/bamlab/generator-rn-toolbox) - Yeoman generators to kickstart your project and setup continuous deployment.
 
 ### Styling
 
-- [cairn ★98](https://github.com/adamterlson/cairn) - Simple, string-based style selector engine with support for basic inheritance.
-- [glamorous-native ★88](https://github.com/robinpowered/glamorous-native) - A React Native version of glamorous - a component styling library.
-- [react-native-css ★584](https://github.com/sabeurthabti/react-native-css) - Style React-Native components with css and built in support for SASS.
-- [react-native-extended-stylesheet ★571](https://github.com/vitalets/react-native-extended-stylesheet) - Extend React Native stylesheet with variables, relative units, percents, math operations, scaling and other stuff.
-- [react-native-responsive ★145](https://github.com/ayoubdev/react-native-responsive) - The power of Media Queries now in your React Native project (ios and android) ! Responsive Design can now be easily managed !
-- [react-native-theme ★40](https://github.com/apentle/react-native-theme) - Theme manager for react native project!
-- [react-native-style-tachyons ★221](https://github.com/tachyons-css/react-native-style-tachyons) - functional, maintainable design for everyone based on tachyons.css.
-- [rn-less ★6](https://github.com/blackmiaool/rn-less) - Style react-native with less (with VS Code extension support)
-- [styled-components](https://github.com/styled-components/styled-components) - Style React and React Native with utilising tagged template literals.
+- [cairn ★108](https://github.com/adamterlson/cairn) - Simple, string-based style selector engine with support for basic inheritance.
+- [glamorous-native ★265](https://github.com/robinpowered/glamorous-native) - A React Native version of glamorous - a component styling library.
+- [react-native-css ★678](https://github.com/sabeurthabti/react-native-css) - Style React-Native components with css and built in support for SASS.
+- [react-native-extended-stylesheet ★1042](https://github.com/vitalets/react-native-extended-stylesheet) - Extend React Native stylesheet with variables, relative units, percents, math operations, scaling and other stuff.
+- [react-native-responsive ★216](https://github.com/ayoubdev/react-native-responsive) - The power of Media Queries now in your React Native project (ios and android) ! Responsive Design can now be easily managed !
+- [react-native-theme ★74](https://github.com/apentle/react-native-theme) - Theme manager for react native project!
+- [react-native-style-tachyons ★382](https://github.com/tachyons-css/react-native-style-tachyons) - functional, maintainable design for everyone based on tachyons.css.
+- [rn-less ★11](https://github.com/blackmiaool/rn-less) - Style react-native with less (with VS Code extension support)
+- [styled-components ★11618](https://github.com/styled-components/styled-components) - Style React and React Native with utilising tagged template literals.
 
 
 ### System
-- [react-native-incall-manager ★172](https://github.com/zxcpoiu/react-native-incall-manager) - Handling media-routes/sensors/events during a audio/video chat on React Native
-- [react-native-addressbook ★65](https://github.com/rt2zz/react-native-addressbook) - AddressBook module for react-native
-- [react-native-android-sms-listener ★66](https://github.com/CentaurWarchief/react-native-android-sms-listener) - Allows you to listen for incoming SMS messages
-- [react-native-android-sms ★34](https://github.com/msmakhlouf/react-native-android-sms) - A react native android module to list/send sms.
-- [react-native-android-speech ★27](https://github.com/mihirsoni/react-native-android-speech) - A text-to-speech library for Android React Native.
-- [react-native-android-sqlite ★28](https://github.com/jbrodriguez/react-native-android-sqlite) - A react native android wrapper for SQLite
-- [react-native-app-info ★33](https://github.com/Iragne/react-native-app-info) - React Native app info and version
-- [react-native-arkit ★38](https://github.com/HippoAR/react-native-arkit) - React Native binding for iOS ARKit
-- [react-native-background-fetch ★169](https://github.com/transistorsoft/react-native-background-fetch) - iOS BackgroundFetch API implementation.  Awakens a suspended iOS app in the background to execute a `callbackFn` about every 15 min.
-- [react-native-barcode-scanner ★50](https://github.com/lifuzu/ReactNativeBarcodeScanner) - Barcode scanner for React Native
-- [react-native-barcodescanner ★298](https://github.com/ideacreation/react-native-barcodescanner) - A barcode scanner component for react native - not maintained anymore - use react-native-camera.
-- [react-native-battery-status ★3](https://github.com/remobile/react-native-battery-status) - A battery-status for react-native
-- [react-native-battery ★12](https://github.com/oojr/react-native-battery) - A React Native module that returns the battery level/status of a device
-- [react-native-ble ★116](https://github.com/jacobrosenthal/react-native-ble) - React Native BLE using noble api surface
-- [react-native-bluetooth-state ★37](https://github.com/frostney/react-native-bluetooth-state) - Answering the question of "Is my bluetooth on?" in React Native
-- [react-native-callkit ★13](https://github.com/ianlin/react-native-callkit) - iOS 10 CallKit framework for React Native
-- [react-native-calendar-reminders ★43](https://github.com/wmcmahan/React-Native-CalendarReminders) - React Native module for IOS EventKit Reminders
-- [react-native-carrier-info ★11](https://github.com/anarchicknight/react-native-carrier-info) - React Native module bridge to obtain information about the user’s home cellular service provider.
-- [react-native-clipboard ★50](https://github.com/silentcloud/react-native-clipboard) - React Native component for getting or setting clipboard content
-- [react-native-communications ★363](https://github.com/anarchicknight/react-native-communications) - Easily call, email, text or iMessage someone in React Native
-- [react-native-config ★388](https://github.com/luggit/react-native-config) - Config variables for React Native apps
-- [react-native-dotenv](https://github.com/zetachang/react-native-dotenv) - A Babel preset let you import application configs from .env file (zero runtime dependency)
-- [react-native-contacts-rx ★10](https://github.com/JeanLebrument/react-native-contacts-rx) - react-native-contacts counterpart that include the support of RxJS.
-- [react-native-contacts ★319](https://github.com/rt2zz/react-native-contacts) - React Native Contacts (android & ios)
-- [react-native-unified-contacts ★61](https://github.com/joshuapinter/react-native-unified-contacts) - React Native iOS 9+ Contacts (ios)
-- [react-native-detect-device ★10](https://github.com/peachmeco/react-native-detect-device) - Detect a device on iOS or android in react-native.
-- [react-native-device-battery ★11](https://github.com/robinpowered/react-native-device-battery) - Observe battery state changes in your react native application
-- [react-native-device-info-pod ★1](https://github.com/mchinyakov/react-native-device-info) - Get device information using react-native
-- [react-native-device-info ★858](https://github.com/rebeccahughes/react-native-device-info) - Get device information using react-native
-- [react-native-device-motion ★25](https://github.com/paramaggarwal/react-native-device-motion) - iOS device motion wrapper for React Native.
-- [react-native-device ★161](https://github.com/GertjanReynaert/react-native-device) - UIDevice wrapper for React Native
-- [react-native-discovery ★36](https://github.com/yonahforst/react-native-discovery) - Discover nearby devics using BLE. Turn iOS and Android devices into beacons
-- [react-native-fs ★905](https://github.com/johanneslumpe/react-native-fs) - Native filesystem access for react-native
-- [react-native-onesignal ★255](https://github.com/geektimecoil/react-native-onesignal) - React Native Library for OneSignal Push Notifications Service (iOS + Android)
-- [react-native-gcm-android ★155](https://github.com/oney/react-native-gcm-android) - GCM for Android
-- [react-native-heading ★14](https://github.com/yonahforst/react-native-heading) - Get device heading (compass) information on iOS or Android
-- [react-native-ibeacon ★223](https://github.com/geniuxconsulting/react-native-ibeacon) - iBeacon support for React Native. The API is very similar to the CoreLocation Objective-C one with the only major difference that regions are plain JavaScript objects. Beacons don't work in the iOS simulator.
-- [react-native-icloud-sync ★24](https://github.com/chirag04/react-native-icloud-sync) - A react-native wrapper for syncing with icloud
-- [react-native-in-app-utils ★265](https://github.com/chirag04/react-native-in-app-utils) - A react-native wrapper for handling in-app payments.
-- [react-native-image-resizer ★189](https://github.com/bamlab/react-native-image-resizer) - Rescale local image files with React Native.
-- [react-native-scalable-image ★9](https://github.com/ihor/react-native-scalable-image) - React Native Image component which scales width or height automatically to keep the original aspect ratio.
-- [react-native-keychain ★243](https://github.com/oblador/react-native-keychain) - Keychain Access for React Native
-- [react-native-localsearch ★16](https://github.com/wmcmahan/React-Native-LocalSearch) - React Native Module for MapKit Local Search
-- [react-native-location ★220](https://github.com/timfpark/react-native-location) - Native GPS location support for React Native.
+- [react-native-incall-manager ★174](https://github.com/zxcpoiu/react-native-incall-manager) - Handling media-routes/sensors/events during a audio/video chat on React Native
+- [react-native-addressbook ★78](https://github.com/rt2zz/react-native-addressbook) - AddressBook module for react-native
+- [react-native-android-sms-listener ★123](https://github.com/CentaurWarchief/react-native-android-sms-listener) - Allows you to listen for incoming SMS messages
+- [react-native-android-sms ★42](https://github.com/msmakhlouf/react-native-android-sms) - A react native android module to list/send sms.
+- [react-native-android-speech ★44](https://github.com/mihirsoni/react-native-android-speech) - A text-to-speech library for Android React Native.
+- [react-native-android-sqlite ★27](https://github.com/jbrodriguez/react-native-android-sqlite) - A react native android wrapper for SQLite
+- [react-native-app-info ★37](https://github.com/Iragne/react-native-app-info) - React Native app info and version
+- [react-native-arkit ★767](https://github.com/HippoAR/react-native-arkit) - React Native binding for iOS ARKit
+- [react-native-background-fetch ★177](https://github.com/transistorsoft/react-native-background-fetch) - iOS BackgroundFetch API implementation.  Awakens a suspended iOS app in the background to execute a `callbackFn` about every 15 min.
+- [react-native-barcode-scanner ★55](https://github.com/lifuzu/ReactNativeBarcodeScanner) - Barcode scanner for React Native
+- [react-native-barcodescanner ★420](https://github.com/ideacreation/react-native-barcodescanner) - A barcode scanner component for react native - not maintained anymore - use react-native-camera.
+- [react-native-battery-status ★6](https://github.com/remobile/react-native-battery-status) - A battery-status for react-native
+- [react-native-battery ★17](https://github.com/oojr/react-native-battery) - A React Native module that returns the battery level/status of a device
+- [react-native-ble ★143](https://github.com/jacobrosenthal/react-native-ble) - React Native BLE using noble api surface
+- [react-native-bluetooth-state ★54](https://github.com/frostney/react-native-bluetooth-state) - Answering the question of "Is my bluetooth on?" in React Native
+- [react-native-callkit ★49](https://github.com/ianlin/react-native-callkit) - iOS 10 CallKit framework for React Native
+- [react-native-calendar-reminders ★57](https://github.com/wmcmahan/React-Native-CalendarReminders) - React Native module for IOS EventKit Reminders
+- [react-native-carrier-info ★22](https://github.com/anarchicknight/react-native-carrier-info) - React Native module bridge to obtain information about the user’s home cellular service provider.
+- [react-native-clipboard ★53](https://github.com/silentcloud/react-native-clipboard) - React Native component for getting or setting clipboard content
+- [react-native-communications ★651](https://github.com/anarchicknight/react-native-communications) - Easily call, email, text or iMessage someone in React Native
+- [react-native-config ★990](https://github.com/luggit/react-native-config) - Config variables for React Native apps
+- [react-native-dotenv ★209](https://github.com/zetachang/react-native-dotenv) - A Babel preset let you import application configs from .env file (zero runtime dependency)
+- [react-native-contacts-rx ★12](https://github.com/JeanLebrument/react-native-contacts-rx) - react-native-contacts counterpart that include the support of RxJS.
+- [react-native-contacts ★571](https://github.com/rt2zz/react-native-contacts) - React Native Contacts (android & ios)
+- [react-native-unified-contacts ★94](https://github.com/joshuapinter/react-native-unified-contacts) - React Native iOS 9+ Contacts (ios)
+- [react-native-detect-device ★11](https://github.com/peachmeco/react-native-detect-device) - Detect a device on iOS or android in react-native.
+- [react-native-device-battery ★17](https://github.com/robinpowered/react-native-device-battery) - Observe battery state changes in your react native application
+- [react-native-device-info-pod ★2](https://github.com/mchinyakov/react-native-device-info) - Get device information using react-native
+- [react-native-device-info ★1810](https://github.com/rebeccahughes/react-native-device-info) - Get device information using react-native
+- [react-native-device-motion ★26](https://github.com/paramaggarwal/react-native-device-motion) - iOS device motion wrapper for React Native.
+- [react-native-device ★181](https://github.com/GertjanReynaert/react-native-device) - UIDevice wrapper for React Native
+- [react-native-discovery ★54](https://github.com/yonahforst/react-native-discovery) - Discover nearby devics using BLE. Turn iOS and Android devices into beacons
+- [react-native-fs ★1622](https://github.com/johanneslumpe/react-native-fs) - Native filesystem access for react-native
+- [react-native-onesignal ★556](https://github.com/geektimecoil/react-native-onesignal) - React Native Library for OneSignal Push Notifications Service (iOS + Android)
+- [react-native-gcm-android ★168](https://github.com/oney/react-native-gcm-android) - GCM for Android
+- [react-native-heading ★21](https://github.com/yonahforst/react-native-heading) - Get device heading (compass) information on iOS or Android
+- [react-native-ibeacon ★294](https://github.com/geniuxconsulting/react-native-ibeacon) - iBeacon support for React Native. The API is very similar to the CoreLocation Objective-C one with the only major difference that regions are plain JavaScript objects. Beacons don't work in the iOS simulator.
+- [react-native-icloud-sync ★33](https://github.com/chirag04/react-native-icloud-sync) - A react-native wrapper for syncing with icloud
+- [react-native-in-app-utils ★508](https://github.com/chirag04/react-native-in-app-utils) - A react-native wrapper for handling in-app payments.
+- [react-native-image-resizer ★411](https://github.com/bamlab/react-native-image-resizer) - Rescale local image files with React Native.
+- [react-native-scalable-image ★17](https://github.com/ihor/react-native-scalable-image) - React Native Image component which scales width or height automatically to keep the original aspect ratio.
+- [react-native-keychain ★517](https://github.com/oblador/react-native-keychain) - Keychain Access for React Native
+- [react-native-localsearch ★14](https://github.com/wmcmahan/React-Native-LocalSearch) - React Native Module for MapKit Local Search
+- [react-native-location ★356](https://github.com/timfpark/react-native-location) - Native GPS location support for React Native.
 - [react-native-lock-android ★7](https://github.com/auth0/react-native-lock-android) - Auth0 Lock for React Native (Android)
-- [react-native-lock-ios ★208](https://github.com/auth0/react-native-lock-ios) - Auth0 Lock for React Native (iOS)
-- [react-native-mipush ★8](https://github.com/cpunion/react-native-mipush) - MiPush for React Native
-- [react-native-motion-manager ★151](https://github.com/pwmckenna/react-native-motion-manager) - A react-native interface for using the Gyroscope, Accelerometer and Magnetometer
-- [react-native-device-angles ★3](https://github.com/cristianszwarc/RNDeviceAngles) - Get rotation information in degrees (pitch, yaw, roll) - ios
-- [react-native-passcode-auth ★42](https://github.com/naoufal/react-native-passcode-auth) - React Native authentication with iOS Passcode.
-- [react-native-permissions ★326](https://github.com/yonahforst/react-native-permissions) - Check and request all permissions with a single api
-- [react-native-push-notification ★1114](https://github.com/zo0r/react-native-push-notification) - React Native Local and Remote Notifications
-- [react-native-phone-call ★16](https://github.com/tiaanduplessis/react-native-phone-call) - A simple way to initiate a phone call in React Native
-- [react-native-notifications ★264](https://github.com/wix/react-native-notifications) - React native notifications
-- [react-native-nfc-ios ★7](https://github.com/barodeur/react-native-nfc-ios) - Easy to use CoreNFC for React Native
-- [react-native-fcm ★445](https://github.com/evollu/react-native-fcm) - react native module for firebase cloud messaging and local notification
-- [react-native-push-with-gcm ★3](https://github.com/lilach/react-native-push-with-gcm) - Register device for GCM push notifications services (supported only for iOS)
-- [react-native-search-api ★13](https://github.com/ombori/react-native-search-api) - The SearchApi module gives you a general React Native interface to interact with the iOS Search API, Core Spotlight.
-- [react-native-sensor-manager ★84](https://github.com/kprimice/react-native-sensor-manager) - Wrapper for react-native providing native sensors access. (Gyroscope, accelerometer, magnetometer, thermometer...)
-- [react-native-sms-android ★12](https://github.com/rhaker/react-native-sms-android) - A react-native module for sending a sms message to a phone number.
-- [react-native-social-share ★198](https://github.com/doefler/react-native-social-share) - Use the iOS native Twitter and Facebook share view from react native
-- [react-native-system-notification ★2](https://github.com/Neson/react-native-system-notification) - Notification for React Native
-- [react-native-touch-id ★304](https://github.com/naoufal/react-native-touch-id) - React Native authentication with the native Touch ID popup.
-- [react-native-fingerprint-identify ★12](https://github.com/williamtran29/react-native-fingerprint-identify) - React Native authentication with the Fingerprint on Android, fingerprint API compatible lib, which also combines Samsung, Xiaomi and MeiZu's official Fingerprint API.
-- [react-native-touch-id-android ★18](https://github.com/ElekenAgency/react-native-touch-id-android) - React Native authentication with the Fingerprint on Android.
-- [react-native-voip-push-notification ★14](https://github.com/ianlin/react-native-voip-push-notification) - iOS prioritized VoIP Push Notification
-- [react-native-wifi-manager ★14](https://github.com/skierkowski/react-native-wifi-manager) - Wifi Connection Manager for React Native on Android
-- [react-native-billing ★171](https://github.com/idehub/react-native-billing) - In-app purchase implementation for React Native on Android.
-- [react-native-haptic ★29](https://github.com/charlesvinette/react-native-haptic) - iOS 10 + haptic feedback for React Native applications
-- [react-native-quick-actions ★287](https://github.com/madriska/react-native-quick-actions) - A react-native interface for 3D Touch home screen quick actions
-- [react-native-firebase ★1420](https://github.com/invertase/react-native-firebase) - A well tested feature rich Firebase implementation for React Native, supporting both iOS & Android platforms for 10+ Firebase modules (including Cloud Firestore).
+- [react-native-lock-ios ★289](https://github.com/auth0/react-native-lock-ios) - Auth0 Lock for React Native (iOS)
+- [react-native-mipush ★11](https://github.com/cpunion/react-native-mipush) - MiPush for React Native
+- [react-native-motion-manager ★194](https://github.com/pwmckenna/react-native-motion-manager) - A react-native interface for using the Gyroscope, Accelerometer and Magnetometer
+- [react-native-device-angles ★9](https://github.com/cristianszwarc/RNDeviceAngles) - Get rotation information in degrees (pitch, yaw, roll) - ios
+- [react-native-passcode-auth ★62](https://github.com/naoufal/react-native-passcode-auth) - React Native authentication with iOS Passcode.
+- [react-native-permissions ★518](https://github.com/yonahforst/react-native-permissions) - Check and request all permissions with a single api
+- [react-native-push-notification ★2224](https://github.com/zo0r/react-native-push-notification) - React Native Local and Remote Notifications
+- [react-native-phone-call ★22](https://github.com/tiaanduplessis/react-native-phone-call) - A simple way to initiate a phone call in React Native
+- [react-native-notifications ★757](https://github.com/wix/react-native-notifications) - React native notifications
+- [react-native-nfc-ios ★33](https://github.com/barodeur/react-native-nfc-ios) - Easy to use CoreNFC for React Native
+- [react-native-fcm ★1052](https://github.com/evollu/react-native-fcm) - react native module for firebase cloud messaging and local notification
+- [react-native-push-with-gcm ★5](https://github.com/lilach/react-native-push-with-gcm) - Register device for GCM push notifications services (supported only for iOS)
+- [react-native-search-api ★21](https://github.com/ombori/react-native-search-api) - The SearchApi module gives you a general React Native interface to interact with the iOS Search API, Core Spotlight.
+- [react-native-sensor-manager ★133](https://github.com/kprimice/react-native-sensor-manager) - Wrapper for react-native providing native sensors access. (Gyroscope, accelerometer, magnetometer, thermometer...)
+- [react-native-sms-android ★26](https://github.com/rhaker/react-native-sms-android) - A react-native module for sending a sms message to a phone number.
+- [react-native-social-share ★281](https://github.com/doefler/react-native-social-share) - Use the iOS native Twitter and Facebook share view from react native
+- [react-native-system-notification ★6](https://github.com/Neson/react-native-system-notification) - Notification for React Native
+- [react-native-touch-id ★522](https://github.com/naoufal/react-native-touch-id) - React Native authentication with the native Touch ID popup.
+- [react-native-fingerprint-identify ★69](https://github.com/williamtran29/react-native-fingerprint-identify) - React Native authentication with the Fingerprint on Android, fingerprint API compatible lib, which also combines Samsung, Xiaomi and MeiZu's official Fingerprint API.
+- [react-native-touch-id-android ★22](https://github.com/ElekenAgency/react-native-touch-id-android) - React Native authentication with the Fingerprint on Android.
+- [react-native-voip-push-notification ★26](https://github.com/ianlin/react-native-voip-push-notification) - iOS prioritized VoIP Push Notification
+- [react-native-wifi-manager ★22](https://github.com/skierkowski/react-native-wifi-manager) - Wifi Connection Manager for React Native on Android
+- [react-native-billing ★351](https://github.com/idehub/react-native-billing) - In-app purchase implementation for React Native on Android.
+- [react-native-haptic ★56](https://github.com/charlesvinette/react-native-haptic) - iOS 10 + haptic feedback for React Native applications
+- [react-native-quick-actions ★481](https://github.com/madriska/react-native-quick-actions) - A react-native interface for 3D Touch home screen quick actions
+- [react-native-firebase ★1685](https://github.com/invertase/react-native-firebase) - A well tested feature rich Firebase implementation for React Native, supporting both iOS & Android platforms for 10+ Firebase modules (including Cloud Firestore).
 
 ### Web
 
-- [react-native-bridgeable-webview ★11](https://github.com/Intellicode/react-native-bridgeable-webview) - A react-native webview with bridge to react-native code
-- [react-native-browser-polyfill ★21](https://github.com/johanneslumpe/react-native-browser-polyfill) - A collection of polyfills for the react-native Javascript environment.
-- [react-native-browser ★59](https://github.com/PrestoDoctor/react-native-browser) - Full-featured web browser module for React Native apps, based on TOWebViewController
-- [react-native-for-web ★216](https://github.com/KodersLab/react-native-for-web) - A set of classes and react components to make work your react-native app in a browser. (with some limitations obviously)
+- [react-native-bridgeable-webview ★14](https://github.com/Intellicode/react-native-bridgeable-webview) - A react-native webview with bridge to react-native code
+- [react-native-browser-polyfill ★24](https://github.com/johanneslumpe/react-native-browser-polyfill) - A collection of polyfills for the react-native Javascript environment.
+- [react-native-browser ★78](https://github.com/PrestoDoctor/react-native-browser) - Full-featured web browser module for React Native apps, based on TOWebViewController
+- [react-native-for-web ★234](https://github.com/KodersLab/react-native-for-web) - A set of classes and react components to make work your react-native app in a browser. (with some limitations obviously)
 - [react-native-h5 ★0](https://github.com/dingui/react-native-h5) - react native web
-- [react-native-html2native ★2](https://github.com/labithiotis/react-native-html-render) - A html render for react-native
-- [react-native-inapp-browser ★11](https://github.com/DickyT/react-native-inapp-browser) - A in-app browser for react native apps.
-- [react-native-safari-view ★186](https://github.com/naoufal/react-native-safari-view) - A React Native wrapper for Safari View Controller
-- [react-native-web-container ★13](https://github.com/danrigsby/react-native-web-container) - A wrapper around the react native WebView to add autoHeight, scrub html, etc
+- [react-native-html2native ★3](https://github.com/labithiotis/react-native-html-render) - A html render for react-native
+- [react-native-inapp-browser ★17](https://github.com/DickyT/react-native-inapp-browser) - A in-app browser for react native apps.
+- [react-native-safari-view ★289](https://github.com/naoufal/react-native-safari-view) - A React Native wrapper for Safari View Controller
+- [react-native-web-container ★28](https://github.com/danrigsby/react-native-web-container) - A wrapper around the react native WebView to add autoHeight, scrub html, etc
 - [react-native-web-polyfill ★23](https://github.com/mattiamanzati/react-native-web-polyfill) - A set of classes and react components to make work your react-native app in a browser. (with some limitations obviously)
-- [react-native-webintent ★47](https://github.com/ivanph/react-native-webintent) - React native android module to open links in the default browser
-- [react-native-webrtc ★690](https://github.com/oney/react-native-webrtc) - A WebRTC module for React Native.
-- [react-native-webview-android ★148](https://github.com/lucasferreira/react-native-webview-android) - Simple React Native Android module to use Android's WebView inside your app
-- [react-native-webview-bridge ★653](https://github.com/alinz/react-native-webview-bridge) - React Native WebView Javascript Bridge
-- [react-native-webview ★1](https://github.com/beefe/react-native-webview) - android webview for react-native
-- [react-native-cookiemanager ★7](https://github.com/beefe/react-native-cookiemanager) - react-native cookie manager library.
-- [react-native-webview-crosswalk ★42](https://github.com/jordansexton/react-native-webview-crosswalk) - Crosswalk's WebView for React Native on Android
+- [react-native-webintent ★51](https://github.com/ivanph/react-native-webintent) - React native android module to open links in the default browser
+- [react-native-webrtc ★1193](https://github.com/oney/react-native-webrtc) - A WebRTC module for React Native.
+- [react-native-webview-android ★209](https://github.com/lucasferreira/react-native-webview-android) - Simple React Native Android module to use Android's WebView inside your app
+- [react-native-webview-bridge ★918](https://github.com/alinz/react-native-webview-bridge) - React Native WebView Javascript Bridge
+- [react-native-webview ★2](https://github.com/beefe/react-native-webview) - android webview for react-native
+- [react-native-cookiemanager ★12](https://github.com/beefe/react-native-cookiemanager) - react-native cookie manager library.
+- [react-native-webview-crosswalk ★71](https://github.com/jordansexton/react-native-webview-crosswalk) - Crosswalk's WebView for React Native on Android
 
 ### Media
-- [react-native-interactive-image-gallery ★3](https://github.com/InterfaceKit/react-native-interactive-image-gallery) - A React Native component to display a gallery of images.
-- [react-native-android-audio-streaming-aac ★19](https://github.com/EstebanFuentealba/react-native-android-audio-streaming-aac) - A react native streaming player
-- [react-native-audio-manager ★13](https://github.com/Tricy/react-native-audio-manager) - Audio player library for react native Android
+- [react-native-interactive-image-gallery ★6](https://github.com/InterfaceKit/react-native-interactive-image-gallery) - A React Native component to display a gallery of images.
+- [react-native-android-audio-streaming-aac ★22](https://github.com/EstebanFuentealba/react-native-android-audio-streaming-aac) - A react native streaming player
+- [react-native-audio-manager ★14](https://github.com/Tricy/react-native-audio-manager) - Audio player library for react native Android
 - [react-native-audio-player ★11](https://github.com/sh3rawi/react-native-audio-player) - A React Native module to play audio on Android
-- [react-native-audioplayer ★82](https://github.com/andreaskeller/react-native-audioplayer) - Small audio player library for react native
-- [react-native-audio ★246](https://github.com/jsierles/react-native-audio) - Record and play back audio in your iOS or Android React Native apps.
-- [react-native-camera-kit ★283](https://github.com/wix/react-native-camera-kit) - Advanced native camera and gallery components and device photos API.
-- [react-native-camera ★2519](https://github.com/lwansbrough/react-native-camera) - Camera component
-- [react-native-color-grabber ★31](https://github.com/bsudekum/react-native-color-grabber) - React native component for finding dominant colors in an image
-- [react-native-incall-manager ★97](https://github.com/zxcpoiu/react-native-incall-manager) - Handling media-routes/sensors/events during a audio/video chat like webrtc
-- [react-native-media-capture ★2](https://github.com/remobile/react-native-media-capture) - A media-capture for react-native
-- [react-native-mediaplayer ★8](https://github.com/chriselly/react-native-mediaplayer) - Simple full screen media player for React Native.
-- [react-native-media-meta ★10](https://github.com/mybigday/react-native-media-meta) - Get media file metadata in your React Native app
-- [react-native-photos-framework ★31](https://github.com/olofd/react-native-photos-framework) - A modern and comprehensive CameraRoll/iCloud-library for React Native
-- [react-native-player ★62](https://github.com/xeodou/react-native-player) - Media player for react-native
-- [react-native-screcorder ★165](https://github.com/maxs15/react-native-screcorder) - Capture pictures and record Video with Vine-like tap to record
-- [react-native-simple-sound ★9](https://github.com/mikehedman/react-native-simple-sound) - Start, stop, and pause a sound. iOS only. Derived from https://github.com/zmxv/react-native-sound
-- [react-native-sound ★431](https://github.com/zmxv/react-native-sound) - React Native module for playing sound clips
-- [react-native-sound-demo ★6](https://github.com/zmxv/react-native-sound-demo) - react-native-sound demo project
-- [react-native-sound-recorder ★8](https://github.com/kevinresol/react-native-sound-recorder) - No-hassle Sound Recorder for React Native.
-- [react-native-speech ★123](https://github.com/naoufal/react-native-speech) - A text-to-speech library for React Native.
-- [react-native-track-player ★23](https://github.com/react-native-kit/react-native-track-player) - A fully fledged audio module created for music apps. Provides audio playback, external media controls, chromecast support and background mode for Android, iOS and Windows.
-- [react-native-video ★1483](https://github.com/brentvatne/react-native-video) - A Video component for react-native
-- [react-native-fullscreen-video](https://github.com/mostafa/react-native-fullscreen-video) - A full-screen video component on top of react-native-video
-- [react-native-volume-slider ★29](https://github.com/IFours/react-native-volume-slider) - React Native VolumeView component
-- [react-native-vlc-player ★34](https://github.com/ghondar/react-native-vlc-player) - VLC Player for react-native
-- [react-native-camera-roll-picker ★108](https://github.com/jeanpan/react-native-camera-roll-picker) - A React Native component providing images selection from camera roll
-- [react-native-audio-streaming ★262](https://github.com/tlenclos/react-native-audio-streaming) - iOS & Android module to play an audio stream, with background support and media controls :speaker:
-- [react-native-video-processing ★112](https://github.com/shahen94/react-native-video-processing) - Native Video editing/trimming/filtering library for React-Native
+- [react-native-audioplayer ★94](https://github.com/andreaskeller/react-native-audioplayer) - Small audio player library for react native
+- [react-native-audio ★530](https://github.com/jsierles/react-native-audio) - Record and play back audio in your iOS or Android React Native apps.
+- [react-native-camera-kit ★360](https://github.com/wix/react-native-camera-kit) - Advanced native camera and gallery components and device photos API.
+- [react-native-camera ★4230](https://github.com/lwansbrough/react-native-camera) - Camera component
+- [react-native-color-grabber ★40](https://github.com/bsudekum/react-native-color-grabber) - React native component for finding dominant colors in an image
+- [react-native-incall-manager ★174](https://github.com/zxcpoiu/react-native-incall-manager) - Handling media-routes/sensors/events during a audio/video chat like webrtc
+- [react-native-media-capture ★5](https://github.com/remobile/react-native-media-capture) - A media-capture for react-native
+- [react-native-mediaplayer ★9](https://github.com/chriselly/react-native-mediaplayer) - Simple full screen media player for React Native.
+- [react-native-media-meta ★15](https://github.com/mybigday/react-native-media-meta) - Get media file metadata in your React Native app
+- [react-native-photos-framework ★92](https://github.com/olofd/react-native-photos-framework) - A modern and comprehensive CameraRoll/iCloud-library for React Native
+- [react-native-player ★73](https://github.com/xeodou/react-native-player) - Media player for react-native
+- [react-native-screcorder ★198](https://github.com/maxs15/react-native-screcorder) - Capture pictures and record Video with Vine-like tap to record
+- [react-native-simple-sound ★10](https://github.com/mikehedman/react-native-simple-sound) - Start, stop, and pause a sound. iOS only. Derived from https://github.com/zmxv/react-native-sound
+- [react-native-sound ★957](https://github.com/zmxv/react-native-sound) - React Native module for playing sound clips
+- [react-native-sound-demo ★31](https://github.com/zmxv/react-native-sound-demo) - react-native-sound demo project
+- [react-native-sound-recorder ★9](https://github.com/kevinresol/react-native-sound-recorder) - No-hassle Sound Recorder for React Native.
+- [react-native-speech ★188](https://github.com/naoufal/react-native-speech) - A text-to-speech library for React Native.
+- [react-native-track-player ★59](https://github.com/react-native-kit/react-native-track-player) - A fully fledged audio module created for music apps. Provides audio playback, external media controls, chromecast support and background mode for Android, iOS and Windows.
+- [react-native-video ★2379](https://github.com/brentvatne/react-native-video) - A Video component for react-native
+- [react-native-fullscreen-video ★17](https://github.com/mostafa/react-native-fullscreen-video) - A full-screen video component on top of react-native-video
+- [react-native-volume-slider ★46](https://github.com/IFours/react-native-volume-slider) - React Native VolumeView component
+- [react-native-vlc-player ★56](https://github.com/ghondar/react-native-vlc-player) - VLC Player for react-native
+- [react-native-camera-roll-picker ★227](https://github.com/jeanpan/react-native-camera-roll-picker) - A React Native component providing images selection from camera roll
+- [react-native-audio-streaming ★531](https://github.com/tlenclos/react-native-audio-streaming) - iOS & Android module to play an audio stream, with background support and media controls :speaker:
+- [react-native-video-processing ★309](https://github.com/shahen94/react-native-video-processing) - Native Video editing/trimming/filtering library for React-Native
 
 ### Storage
 
-- [react-native-couchbase-lite ★71](https://github.com/fraserxu/react-native-couchbase-lite) - couchbase lite binding for react-native
-- [react-native-db-models ★145](https://github.com/darkrishabh/react-native-db-models) - Local DB Models for React Native Apps
-- [react-native-level-fs ★12](https://github.com/tradle/react-native-level-fs) - fs for react-native using level-filesystem and asyncstorage-down
-- [react-native-mongoose ★10](https://github.com/remobile/react-native-mongoose) - A AsyncStorage based mongoose like storage for react-native
-- [react-native-pouchdb ★30](https://github.com/carbureted/react-native-pouchdb) - Run pouchdb in React Native!
-- [react-native-simple-store ★344](https://github.com/jasonmerino/react-native-simple-store) - A minimalistic wrapper around React Native's AsyncStorage.
-- [react-native-sqlite-storage ★668](https://github.com/andpor/react-native-sqlite-storage) - SQLite3 bindings for React Native (Android & iOS)
-- [react-native-sqlite ★474](https://github.com/almost/react-native-sqlite) - SQLite3 bindings for React Native
-- [react-native-sqlite-2 ★13](https://github.com/noradaiko/react-native-sqlite-2) - SQLite3 Native Plugin for React Native for both Android and iOS
-- [react-native-storage ★715](https://github.com/sunnylqm/react-native-storage) - This is a local storage wrapper for both react-native(AsyncStorage) and browser(localStorage). ES6/babel is needed.
-- [react-native-store ★442](https://github.com/thewei/react-native-store) - A simple database base on react-native AsyncStorage.
-- [realm ★1755](https://github.com/realm/realm-js) - An alternative mobile database to SQLite & key-value stores.
-- [pouchdb-adapter-react-native-sqlite ★11](https://github.com/noradaiko/pouchdb-adapter-react-native-sqlite) - PouchDB adapter using ReactNative SQLite as its backing store
-- [react-native-persistent-job ★55](https://github.com/Gabrn/react-native-persistent-job) - Run async tasks that retry after a crash, connection loss or exception
+- [react-native-couchbase-lite ★91](https://github.com/fraserxu/react-native-couchbase-lite) - couchbase lite binding for react-native
+- [react-native-db-models ★158](https://github.com/darkrishabh/react-native-db-models) - Local DB Models for React Native Apps
+- [react-native-level-fs ★16](https://github.com/tradle/react-native-level-fs) - fs for react-native using level-filesystem and asyncstorage-down
+- [react-native-mongoose ★14](https://github.com/remobile/react-native-mongoose) - A AsyncStorage based mongoose like storage for react-native
+- [react-native-pouchdb ★35](https://github.com/carbureted/react-native-pouchdb) - Run pouchdb in React Native!
+- [react-native-simple-store ★536](https://github.com/jasonmerino/react-native-simple-store) - A minimalistic wrapper around React Native's AsyncStorage.
+- [react-native-sqlite-storage ★1054](https://github.com/andpor/react-native-sqlite-storage) - SQLite3 bindings for React Native (Android & iOS)
+- [react-native-sqlite ★523](https://github.com/almost/react-native-sqlite) - SQLite3 bindings for React Native
+- [react-native-sqlite-2 ★46](https://github.com/noradaiko/react-native-sqlite-2) - SQLite3 Native Plugin for React Native for both Android and iOS
+- [react-native-storage ★1427](https://github.com/sunnylqm/react-native-storage) - This is a local storage wrapper for both react-native(AsyncStorage) and browser(localStorage). ES6/babel is needed.
+- [react-native-store ★525](https://github.com/thewei/react-native-store) - A simple database base on react-native AsyncStorage.
+- [realm ★2480](https://github.com/realm/realm-js) - An alternative mobile database to SQLite & key-value stores.
+- [pouchdb-adapter-react-native-sqlite ★29](https://github.com/noradaiko/pouchdb-adapter-react-native-sqlite) - PouchDB adapter using ReactNative SQLite as its backing store
+- [react-native-persistent-job ★57](https://github.com/Gabrn/react-native-persistent-job) - Run async tasks that retry after a crash, connection loss or exception
 
 ### Backend
 
-- [feathers-client ★88](https://github.com/feathersjs/feathers-client) - Feathers client that works with React Native, NodeJS and any client framework.
+- [feathers-client ★102](https://github.com/feathersjs/feathers-client) - Feathers client that works with React Native, NodeJS and any client framework.
 - [react-native-async-http ★3](https://github.com/szq4119/react-native-async-http) - React Native component for async-http
-- [react-native-cognito ★54](https://github.com/morcmarc/react-native-cognito) - AWS Cognito-based authentication module for React Native.
-- [react-native-aws-cognito-js ★27](https://github.com/AirLabsTeam/react-native-aws-cognito-js) - An adaptation of Amazon Cognito Identity SDK for JavaScript in combination with AWS SDK for JavaScript for React Native.
-- [react-native-file-download ★35](https://github.com/plrthink/react-native-file-download) - A simple file download module for react-native
-- [react-native-file-upload ★70](https://github.com/booxood/react-native-file-upload) - A file upload plugin for react-native
+- [react-native-cognito ★58](https://github.com/morcmarc/react-native-cognito) - AWS Cognito-based authentication module for React Native.
+- [react-native-aws-cognito-js ★90](https://github.com/AirLabsTeam/react-native-aws-cognito-js) - An adaptation of Amazon Cognito Identity SDK for JavaScript in combination with AWS SDK for JavaScript for React Native.
+- [react-native-file-download ★41](https://github.com/plrthink/react-native-file-download) - A simple file download module for react-native
+- [react-native-file-upload ★89](https://github.com/booxood/react-native-file-upload) - A file upload plugin for react-native
 - [react-native-http ★11](https://github.com/iktw/react-native-jwt) - React native http
-- [react-native-jwt ★19](https://github.com/StanScates/react-native-jwt) - React native compatible JSON web token utility
-- [react-native-lazyload ★177](https://github.com/magicismight/react-native-lazyload) - lazyload for react native
-- [react-native-meteor ★446](https://github.com/inProgress-team/react-native-meteor) - Full Meteor Client
-- [react-native-multipeer ★71](https://github.com/lwansbrough/react-native-multipeer) - Communicate over ad hoc wifi using Multipeer Connectivity
-- [react-native-networking ★84](https://github.com/eduedix/react-native-networking) - react-native module to download and upload files with AFNetworking
-- [react-native-rest-kit ★57](https://github.com/peter4k/react-native-rest-kit) - A React Native RESTful API kit that use the fetch method
-- [react-native-simple-auth ★289](https://github.com/adamjmcgrath/react-native-simple-auth) - Native social authentication for React Native on iOS
-- [react-native-swift-socketio ★94](https://github.com/kirkness/react-native-swift-socketio) - A react native wrapper for socket.io-client-swift
-- [react-native-tcp ★58](https://github.com/PeelTechnologies/react-native-tcp) - node's net API for react-native
-- [react-native-udp ★59](https://github.com/tradle/react-native-udp) - node's dgram API for react-native
-- [react-native-uploader ★201](https://github.com/aroth/react-native-uploader) - A React Native module to upload files and camera roll assets. Supports progress notification.
-- [react-native-xmpp ★122](https://github.com/aksonov/react-native-xmpp) - XMPP Library for React Native
-- [aws-sdk-react-native ★379](https://github.com/awslabs/aws-sdk-react-native) - AWS SDK for React Native (Official developer preview)
-- [react-native-s3 ★43](https://github.com/mybigday/react-native-s3) - A React Native wrapper for AWS iOS/Android S3 SDK (TransferUtility)
-- [react-native-ssdp ★5](https://github.com/netbeast/react-native-ssdp) - A React Native fork of the SSDP protocol to discover plug and play devices.
-- [react-native-aws3 ★90](https://github.com/benjreinhart/react-native-aws3) - Pure JavaScript React Native library for uploading to AWS S3
-- [react-native-fetch-blob ★573](https://github.com/wkh237/react-native-fetch-blob) - A module integrates network and file system. Supports file stream.
+- [react-native-jwt ★25](https://github.com/StanScates/react-native-jwt) - React native compatible JSON web token utility
+- [react-native-lazyload ★263](https://github.com/magicismight/react-native-lazyload) - lazyload for react native
+- [react-native-meteor ★600](https://github.com/inProgress-team/react-native-meteor) - Full Meteor Client
+- [react-native-multipeer ★95](https://github.com/lwansbrough/react-native-multipeer) - Communicate over ad hoc wifi using Multipeer Connectivity
+- [react-native-networking ★93](https://github.com/eduedix/react-native-networking) - react-native module to download and upload files with AFNetworking
+- [react-native-rest-kit ★62](https://github.com/peter4k/react-native-rest-kit) - A React Native RESTful API kit that use the fetch method
+- [react-native-simple-auth ★469](https://github.com/adamjmcgrath/react-native-simple-auth) - Native social authentication for React Native on iOS
+- [react-native-swift-socketio ★103](https://github.com/kirkness/react-native-swift-socketio) - A react native wrapper for socket.io-client-swift
+- [react-native-tcp ★132](https://github.com/PeelTechnologies/react-native-tcp) - node's net API for react-native
+- [react-native-udp ★109](https://github.com/tradle/react-native-udp) - node's dgram API for react-native
+- [react-native-uploader ★357](https://github.com/aroth/react-native-uploader) - A React Native module to upload files and camera roll assets. Supports progress notification.
+- [react-native-xmpp ★177](https://github.com/aksonov/react-native-xmpp) - XMPP Library for React Native
+- [aws-sdk-react-native ★579](https://github.com/awslabs/aws-sdk-react-native) - AWS SDK for React Native (Official developer preview)
+- [react-native-s3 ★70](https://github.com/mybigday/react-native-s3) - A React Native wrapper for AWS iOS/Android S3 SDK (TransferUtility)
+- [react-native-ssdp ★15](https://github.com/netbeast/react-native-ssdp) - A React Native fork of the SSDP protocol to discover plug and play devices.
+- [react-native-aws3 ★199](https://github.com/benjreinhart/react-native-aws3) - Pure JavaScript React Native library for uploading to AWS S3
+- [react-native-fetch-blob ★1702](https://github.com/wkh237/react-native-fetch-blob) - A module integrates network and file system. Supports file stream.
 - [react-native-nchan ★1](https://github.com/indatawetrust/react-native-nchan) - Nchan (pub/sub server) module for React Native
 
 
 ### Integrations
 
-- [react-native-facebook-account-kit ★79](https://github.com/underscopeio/react-native-facebook-account-kit) - A Facebook Account Kit SDK wrapper for React Native.
+- [react-native-facebook-account-kit ★143](https://github.com/underscopeio/react-native-facebook-account-kit) - A Facebook Account Kit SDK wrapper for React Native.
 - [react-native-amap ★16](https://github.com/laoqiu/react-native-amap) - A React Native component for building maps with the AMap Android SDK
-- [react-native-android-vitamio ★59](https://github.com/sejoker/react-native-android-vitamio) - React-native component for android Vitamio video player
-- [react-native-dialogflow ★26](https://github.com/innFactory/react-native-dialogflow) - A React-Native bridge for Google's Dialogflow (api.ai)
-- [react-native-braintree ★68](https://github.com/alawong/react-native-braintree) - A react native interface for integrating payments using Braintree's v.zero SDK (currently iOS only)
-- [react-native-braintree-android ★16](https://github.com/surialabs/react-native-braintree-android) - Braintree's native Drop-in Payment UI for Android
-- [react-native-braintree-xplat ★22](https://github.com/kraffslol/react-native-braintree-xplat) - Cross-platform Braintree v.zero module.
-- [react-native-card-io ★118](https://github.com/kayla-tech/react-native-card-io) - React Native component for card.io
-- [react-native-awesome-card-io ★100](https://github.com/Kerumen/react-native-awesome-card-io) - A complete and cross-platform card.io component for React Native (iOS and Android)
-- [react-native-conekta ★3](https://github.com/zo0r/react-native-conekta) - Conekta SDK for React Native
+- [react-native-android-vitamio ★69](https://github.com/sejoker/react-native-android-vitamio) - React-native component for android Vitamio video player
+- [react-native-dialogflow ★34](https://github.com/innFactory/react-native-dialogflow) - A React-Native bridge for Google's Dialogflow (api.ai)
+- [react-native-braintree ★85](https://github.com/alawong/react-native-braintree) - A react native interface for integrating payments using Braintree's v.zero SDK (currently iOS only)
+- [react-native-braintree-android ★20](https://github.com/surialabs/react-native-braintree-android) - Braintree's native Drop-in Payment UI for Android
+- [react-native-braintree-xplat ★52](https://github.com/kraffslol/react-native-braintree-xplat) - Cross-platform Braintree v.zero module.
+- [react-native-card-io ★151](https://github.com/kayla-tech/react-native-card-io) - React Native component for card.io
+- [react-native-awesome-card-io ★204](https://github.com/Kerumen/react-native-awesome-card-io) - A complete and cross-platform card.io component for React Native (iOS and Android)
+- [react-native-conekta ★6](https://github.com/zo0r/react-native-conekta) - Conekta SDK for React Native
 - [react-native-digits ★58](https://github.com/fixt/react-native-digits) - Digits wrapper to use in React Native
-- [react-native-fabric-digits ★90](https://github.com/JeanLebrument/react-native-fabric-digits) Fabric Digits wrapper for React-Native
-- [react-native-facebook-login ★712](https://github.com/magus/react-native-facebook-login) - React Native wrapper for native iOS Facebook SDK login button and manager
+- [react-native-fabric-digits ★113](https://github.com/JeanLebrument/react-native-fabric-digits) Fabric Digits wrapper for React-Native
+- [react-native-facebook-login ★965](https://github.com/magus/react-native-facebook-login) - React Native wrapper for native iOS Facebook SDK login button and manager
 - [react-native-fbintent ★3](https://github.com/syarul/react-native-fbintent) - A React Native intent for Android Facebook App
-- [react-native-flurry ★6](https://github.com/amitkothari/react-native-flurry) - React Native wrapper for Flurry
-- [react-native-google-places-autocomplete ★332](https://github.com/FaridSafi/react-native-google-places-autocomplete) - Customizable Google Places autocomplete component for iOS and Android React-Native apps
-- [react-native-google-signin ★382](https://github.com/apptailor/react-native-google-signin) - Google Signin for your react native applications
+- [react-native-flurry ★8](https://github.com/amitkothari/react-native-flurry) - React Native wrapper for Flurry
+- [react-native-google-places-autocomplete ★563](https://github.com/FaridSafi/react-native-google-places-autocomplete) - Customizable Google Places autocomplete component for iOS and Android React-Native apps
+- [react-native-google-signin ★677](https://github.com/apptailor/react-native-google-signin) - Google Signin for your react native applications
 - [react-native-hawk ★4](https://github.com/andyscott/react-native-hawk) - Hawk wrapper for react-native
 - [react-native-heyzap](https://github.com/react-native-contrib/react-native-heyzap)- Heyzap plugin for React Native
-- [react-native-instagram-oauth ★37](https://github.com/watzak/react-native-instagram-oauth) - react-native instagram login
-- [react-native-instagram-share ★14](https://github.com/watzak/react-native-instagram-share) - A react-native interface to share images and videos within instagram (iOS)
-- [react-native-youtube-oauth ★3](https://github.com/indatawetrust/react-native-youtube-oauth) - react-native interface to login to youtube (iOS)
-- [react-instantsearch ★154](https://github.com/algolia/react-instantsearch) - Lightning-fast search for React and React Native apps, by Algolia
-- [react-native-instagram ★1](https://github.com/watzak/react-native-instagram) - react-native instagram wrapper api (iOS)
+- [react-native-instagram-oauth ★50](https://github.com/watzak/react-native-instagram-oauth) - react-native instagram login
+- [react-native-instagram-share ★22](https://github.com/watzak/react-native-instagram-share) - A react-native interface to share images and videos within instagram (iOS)
+- [react-native-youtube-oauth ★4](https://github.com/indatawetrust/react-native-youtube-oauth) - react-native interface to login to youtube (iOS)
+- [react-instantsearch ★296](https://github.com/algolia/react-instantsearch) - Lightning-fast search for React and React Native apps, by Algolia
+- [react-native-instagram ★2](https://github.com/watzak/react-native-instagram) - react-native instagram wrapper api (iOS)
 - [react-native-leancloud ★9](https://github.com/turingou/react-native-leancloud) - a react native LeanCloud component
-- [react-native-level ★32](https://github.com/tradle/react-native-level) - levelup API for react-native AsyncStorage.
-- [react-native-linkedin-login ★29](https://github.com/jodybrewster/react-native-linkedin-login) - Linkedin Login for your react native applications
-- [react-native-onepassword ★21](https://github.com/DriveWealth/react-native-onepassword) - React Native integration with the OnePassword extension.
-- [react-native-qq ★136](https://github.com/reactnativecn/react-native-qq) - QQ Login&Share support in React Native.
-- [react-native-qqsdk ★6](https://github.com/iVanPan/react-native-qqsdk) - A React Native wrapper around the Tencent QQ SDK for Android and iOS. Provides access to QQ ssoLogin, QQ Sharing, QQ Zone Sharing etc.
-- [react-native-realtimemessaging-android ★45](https://github.com/realtime-framework/RCTRealtimeMessagingAndroid) - The Realtime Framework Cloud Messaging Pub/Sub client for React-Native Android
+- [react-native-level ★36](https://github.com/tradle/react-native-level) - levelup API for react-native AsyncStorage.
+- [react-native-linkedin-login ★47](https://github.com/jodybrewster/react-native-linkedin-login) - Linkedin Login for your react native applications
+- [react-native-onepassword ★39](https://github.com/DriveWealth/react-native-onepassword) - React Native integration with the OnePassword extension.
+- [react-native-qq ★230](https://github.com/reactnativecn/react-native-qq) - QQ Login&Share support in React Native.
+- [react-native-qqsdk ★60](https://github.com/iVanPan/react-native-qqsdk) - A React Native wrapper around the Tencent QQ SDK for Android and iOS. Provides access to QQ ssoLogin, QQ Sharing, QQ Zone Sharing etc.
+- [react-native-realtimemessaging-android ★50](https://github.com/realtime-framework/RCTRealtimeMessagingAndroid) - The Realtime Framework Cloud Messaging Pub/Sub client for React-Native Android
 - [react-native-realtimemessaging-ios ★7](https://github.com/realtime-framework/RCTRealtimeMessaging) - The Realtime Framework Cloud Messaging Pub/Sub client for React-Native
-- [react-native-realtime-pusher ★5](https://github.com/gijoehosaphat/react-native-realtime-pusher) - React Native module implementing the Pusher Realtime API
+- [react-native-realtime-pusher ★14](https://github.com/gijoehosaphat/react-native-realtime-pusher) - React Native module implementing the Pusher Realtime API
 - [react-native-realtimestorage-android ★4](https://github.com/realtime-framework/RCTRealtimeStorageAndroid) - The Realtime Cloud Storage client for React-Native Android
 - [react-native-realtimestorage-ios ★7](https://github.com/realtime-framework/RCTRealtimeCloudStorage) - The Realtime Framework Cloud Storage client for React-Native
-- [react-native-sinch-verification ★6](https://github.com/kevinresol/react-native-sinch-verification) - Sinch verification for react native
-- [react-native-testfairy ★4](https://github.com/testfairy/react-native-testfairy) - TestFairy for React Native
-- [react-native-twilio ★55](https://github.com/rogchap/react-native-twilio) - A React Native wrapper for the Twilio Client SDK.
-- [react-native-twilio-programmable-voice ★7](https://github.com/hoxfon/react-native-twilio-programmable-voice) - A React Native wrapper for the Twilio Programmable Voice SDK.
-- [react-native-voximplant ★71](https://github.com/voximplant/react-native-voximplant) - VoxImplant Mobile SDK for embedding voice and video communication into React Native apps.
-- [react-native-wechat-ios ★162](https://github.com/beefe/react-native-wechat-ios) - Wechat SDK for React Native(iOS).
-- [react-native-wechat ★737](https://github.com/weflex/react-native-wechat) - react-native library for wechat app
+- [react-native-sinch-verification ★10](https://github.com/kevinresol/react-native-sinch-verification) - Sinch verification for react native
+- [react-native-testfairy ★9](https://github.com/testfairy/react-native-testfairy) - TestFairy for React Native
+- [react-native-twilio ★69](https://github.com/rogchap/react-native-twilio) - A React Native wrapper for the Twilio Client SDK.
+- [react-native-twilio-programmable-voice ★41](https://github.com/hoxfon/react-native-twilio-programmable-voice) - A React Native wrapper for the Twilio Programmable Voice SDK.
+- [react-native-voximplant ★92](https://github.com/voximplant/react-native-voximplant) - VoxImplant Mobile SDK for embedding voice and video communication into React Native apps.
+- [react-native-wechat-ios ★191](https://github.com/beefe/react-native-wechat-ios) - Wechat SDK for React Native(iOS).
+- [react-native-wechat ★1380](https://github.com/weflex/react-native-wechat) - react-native library for wechat app
 - [react-native-woopra ★11](https://github.com/isair/react-native-woopra) - Promise based Woopra library for react-native
 - [react-native-axmall-alipay ★5](https://github.com/szq4119/react-native-alipay) - react-native alipay
-- [react-native-signalr ★42](https://github.com/olofd/react-native-signalr) - SignalR-client for react-native
-- [react-native-sumup ★2](https://github.com/APSL/react-native-sumup) - A React Native implementation of SumupSDK.
-- [react-native-new-relic ★18](https://github.com/wix/react-native-newrelic) - New Relic event reporting for react-native.
-- [instabug-reactnative ★11](https://github.com/Instabug/instabug-reactnative) - A React Native wrapper for Bug reporting Instabug SDK.
+- [react-native-signalr ★76](https://github.com/olofd/react-native-signalr) - SignalR-client for react-native
+- [react-native-sumup ★4](https://github.com/APSL/react-native-sumup) - A React Native implementation of SumupSDK.
+- [react-native-new-relic ★37](https://github.com/wix/react-native-newrelic) - New Relic event reporting for react-native.
+- [instabug-reactnative ★47](https://github.com/Instabug/instabug-reactnative) - A React Native wrapper for Bug reporting Instabug SDK.
 
 ### Monetization
 
-- [react-native-admob ★246](https://github.com/sbugert/react-native-admob) - A react-native component for Google AdMob banners.
-- [react-native-revmob ★7](https://github.com/RevMob/react-native-revmob) - RevMob wrapper for React Native.
-- [react-native-stripe-api ★64](https://github.com/xcarpentier/react-native-stripe-api) - A small React Native library for Stripe Rest API
+- [react-native-admob ★457](https://github.com/sbugert/react-native-admob) - A react-native component for Google AdMob banners.
+- [react-native-revmob ★10](https://github.com/RevMob/react-native-revmob) - RevMob wrapper for React Native.
+- [react-native-stripe-api ★94](https://github.com/xcarpentier/react-native-stripe-api) - A small React Native library for Stripe Rest API
 
 ### Animation
 
-- [react-native-gl-model-view ★62](https://github.com/rastapasta/react-native-gl-model-view) - Display and animate textured Wavefront .OBJ 3D models with 60fps (iOS)
-- [react-native-animated-sprite ★7](https://github.com/micahrye/react-native-animated-sprite) - A feature rich declarative component for animation, tweening, and dragging sprites.
-- [react-native-interactable ★1606](https://github.com/wix/react-native-interactable) - experimental implementation of high performance interactable views in React Native
-
-
+- [react-native-gl-model-view ★149](https://github.com/rastapasta/react-native-gl-model-view) - Display and animate textured Wavefront .OBJ 3D models with 60fps (iOS)
+- [react-native-animated-sprite ★54](https://github.com/micahrye/react-native-animated-sprite) - A feature rich declarative component for animation, tweening, and dragging sprites.
+- [react-native-interactable ★3016](https://github.com/wix/react-native-interactable) - experimental implementation of high performance interactable views in React Native
 
 ### Other Platforms
 
-- [reactxp ★3686](https://github.com/Microsoft/reactxp) - Library for cross-platform app development
-- [react-native-web ★4731](https://github.com/necolas/react-native-web) - React Native for Web
+- [reactxp ★5553](https://github.com/Microsoft/reactxp) - Library for cross-platform app development
+- [react-native-web ★6831](https://github.com/necolas/react-native-web) - React Native for Web
 - [react-native-watchkit ★0](https://github.com/MystK/react-native-watchkit) - react native for WatchKit
-- [react-native-desktop ★8530](https://github.com/ptmt/react-native-desktop) - React Native for OS X
-- [react-native-windows ★1619](https://github.com/ReactWindows/react-native-windows) - React Native for Universal Windows Platform
-- [react-native-tvos-controller ★2](https://github.com/ycinfinity/react-native-tvos-controller) - TvOS remote controller module for react native.
+- [react-native-desktop ★9725](https://github.com/ptmt/react-native-desktop) - React Native for OS X
+- [react-native-windows ★3169](https://github.com/ReactWindows/react-native-windows) - React Native for Universal Windows Platform
+- [react-native-tvos-controller ★9](https://github.com/ycinfinity/react-native-tvos-controller) - TvOS remote controller module for react native.
 
 ## Utilities
 
 Useful React Native tooling.
 
-- [ADB Auto Restarter ★3](https://github.com/mahanhaz/adb-auto-restarter) - Restart ADB service Automatically in case of crashing while debugging app with device
-- [react-native-snippets ★173](https://github.com/Shrugs/react-native-snippets) - A collection of Sublime Text Snippets for react-native
+- [ADB Auto Restarter ★5](https://github.com/mahanhaz/adb-auto-restarter) - Restart ADB service Automatically in case of crashing while debugging app with device
+- [react-native-snippets ★225](https://github.com/Shrugs/react-native-snippets) - A collection of Sublime Text Snippets for react-native
 - [exponent](https://expo.io/) - Use React Native without XCode (a previewer app + local server infrastructure)
-- [Ruby React Native (via Opal) ★382](https://github.com/zetachang/opal-native) - Use Ruby for building React Native apps
+- [Ruby React Native (via Opal) ★389](https://github.com/zetachang/opal-native) - Use Ruby for building React Native apps
 - [React Native Playground](https://rnplay.org/) - Run React Native apps in your browser via real time simulator
 - [AppHub](https://apphub.io/) - Update React Native apps, instantly
 - [CodePush](http://microsoft.github.io/code-push/) - Push code updates to your apps, instantly
-- [rnpm ★2032](https://github.com/rnpm/rnpm) - react native package manager
-- [rsx ★30](https://github.com/react-native-contrib/rsx) - An alternative to the `react-native` CLI tool
-- [haul ★1029](https://github.com/callstack-io/haul) - command line tool for developing React Native apps
-- [rn-nodeify ★64](https://github.com/mvayngrib/rn-nodeify) - hack to allow react-native projects to use node core modules
+- [rnpm ★2256](https://github.com/rnpm/rnpm) - react native package manager
+- [rsx ★29](https://github.com/react-native-contrib/rsx) - An alternative to the `react-native` CLI tool
+- [haul ★1905](https://github.com/callstack-io/haul) - command line tool for developing React Native apps
+- [rn-nodeify ★189](https://github.com/mvayngrib/rn-nodeify) - hack to allow react-native projects to use node core modules
 - [Deco IDE](https://www.decosoftware.com/) - React Native IDE with components manager
-- [react-native-bundle-visualizer ★32](https://github.com/IjzerenHein/react-native-bundle-visualizer) - See what's inside your RN bundle; useful for optimizing the bundle size
-- [react-native-debugger ★638](https://github.com/jhen0409/react-native-debugger) - The standalone app for React Native Debugger, with React DevTools / Redux DevTools
-- [react-native-exception-handler](https://github.com/master-atul/react-native-exception-handler) – Avoid silent crash and errors on the production build of your app
-- [generact](http://github.com/diegohaz/generact) - CLI that generates components based on existing ones no matter how you structure your app
-- [react-native-rename](https://github.com/junedomingo/react-native-rename) - Rename react-native app with just one command
+- [react-native-bundle-visualizer ★90](https://github.com/IjzerenHein/react-native-bundle-visualizer) - See what's inside your RN bundle; useful for optimizing the bundle size
+- [react-native-debugger ★1908](https://github.com/jhen0409/react-native-debugger) - The standalone app for React Native Debugger, with React DevTools / Redux DevTools
+- [react-native-exception-handler ★185](https://github.com/master-atul/react-native-exception-handler) – Avoid silent crash and errors on the production build of your app
+- [generact ★718](https://github.com/diegohaz/generact) - CLI that generates components based on existing ones no matter how you structure your app
+- [react-native-rename ★468](https://github.com/junedomingo/react-native-rename) - Rename react-native app with just one command
 - [Storybook](https://storybook.js.org) - UI development environment for your React components
-- [Makeicon](https://github.com/beplus/makeicon) - Generates mobile app icons in all resolutions for both iOS and Android
+- [Makeicon ★40](https://github.com/beplus/makeicon) - Generates mobile app icons in all resolutions for both iOS and Android
 - [BugSnag](https://www.bugsnag.com/platforms/react-native-error-reporting/) - A tool that logs native & JS errors. Has a free tier. Includes useful data about the user, environment, session, release, etc.
-- [React Native Actions](https://github.com/lucasbento/react-native-actions) - Run React Native actions from within VSCode.
-- [Electrode Native ★331](https://github.com/electrode-io/electrode-native) - A platform to ease the integration of React Native components in existing mobile applications.
+- [React Native Actions ★37](https://github.com/lucasbento/react-native-actions) - Run React Native actions from within VSCode.
+- [Electrode Native ★235](https://github.com/electrode-io/electrode-native) - A platform to ease the integration of React Native components in existing mobile applications.
 
 ## Seeds
 
 Get a head start on development with an existing seed.
 
-- [🔥 Ignite ★3952](https://github.com/infinitered/ignite) - An unfair start for React Native - Generator CLI for redux/sagas and more.
-- [React Native Seed★219](https://reactnativeseed.com) - A set of React Native Boilerplates to choose from. MobX or Redux for state-management, TypeScript or Flow for static type checking and CRNA or plain React Native for the stack - By the creators of Native Base
-- [React-Native-Starter-Pack ★32](https://github.com/iSimar/React-Native-Starter-Pack) - React Native 0.34 + React-Redux (w/ Redux-Storage) + Native Base + Code Push
-- [react-native-webpack-starter-kit ★829](https://github.com/jhabdas/react-native-webpack-starter-kit)
-- [react-native-babel ★238](https://github.com/roman01la/react-native-babel)
+- [🔥 Ignite ★6704](https://github.com/infinitered/ignite) - An unfair start for React Native - Generator CLI for redux/sagas and more.
+- [React Native Seed ★271](https://github.com/GeekyAnts/react-native-seed) - A set of React Native Boilerplates to choose from. MobX or Redux for state-management, TypeScript or Flow for static type checking and CRNA or plain React Native for the stack - By the creators of Native Base
+- [React-Native-Starter-Pack ★39](https://github.com/iSimar/React-Native-Starter-Pack) - React Native 0.34 + React-Redux (w/ Redux-Storage) + Native Base + Code Push
+- [react-native-webpack-starter-kit ★878](https://github.com/jhabdas/react-native-webpack-starter-kit)
+- [react-native-babel ★239](https://github.com/roman01la/react-native-babel)
 - [react-native-es6-reflux ★145](https://github.com/filp/react-native-es6-reflux)
 - [react-native-tabbed ★23](https://github.com/rxb/react-native-tabbed)
-- [react-native-hot-redux-starter ★134](https://github.com/adampash/react-native-hot-redux-starter)
-- [ReactNativeTS ★190](https://github.com/mrpatiwi/ReactNativeTS) - Boilerplate of a React Native project in Typescript.
-- [Snowflake ★3008](https://github.com/bartonhammond/snowflake) - Android & iOS, Redux, Jest (88% coverage), Immutable, Parse.com
-- [React Native Meteor Boilerplate ★407](https://github.com/spencercarli/react-native-meteor-boilerplate)
-- [MeteorNative Boilerplate ★18](https://github.com/redbaron76/MeteorNative) - a React Native and Meteor boilerplate with Redux.
-- [Pepperoni ★3157](https://github.com/futurice/pepperoni-app-kit) - Starter kit for Android & iOS, Redux, Immutable.js, disk-persisted app state
-- [Rhinos-app ★57](https://github.com/rhinos-app/rhinos-app-dev) - Cross-platform React Native boilerplate (iOS, Android, Web) built on react-native-web.
-- [rn-mobx-template ★9](https://github.com/hiaw/rn_mobx_template) - React Native with MobX template
+- [react-native-hot-redux-starter ★136](https://github.com/adampash/react-native-hot-redux-starter)
+- [ReactNativeTS ★337](https://github.com/mrpatiwi/ReactNativeTS) - Boilerplate of a React Native project in Typescript.
+- [Snowflake ★3829](https://github.com/bartonhammond/snowflake) - Android & iOS, Redux, Jest (88% coverage), Immutable, Parse.com
+- [React Native Meteor Boilerplate ★540](https://github.com/spencercarli/react-native-meteor-boilerplate)
+- [MeteorNative Boilerplate ★22](https://github.com/redbaron76/MeteorNative) - a React Native and Meteor boilerplate with Redux.
+- [Pepperoni ★3950](https://github.com/futurice/pepperoni-app-kit) - Starter kit for Android & iOS, Redux, Immutable.js, disk-persisted app state
+- [Rhinos-app ★72](https://github.com/rhinos-app/rhinos-app-dev) - Cross-platform React Native boilerplate (iOS, Android, Web) built on react-native-web.
+- [rn-mobx-template ★16](https://github.com/hiaw/rn_mobx_template) - React Native with MobX template
 - [rn-relay-drawer-template ★4](https://github.com/hiaw/rn-relay-drawer-template) - React Native working with RNRF, drawer and relay
-- [React Native Hackathon Starter ★213](https://github.com/dabit3/react-native-hackathon-starter) - React Native Starter Project, great for hackathons or rapid prototyping. Includes tabs, navigation, Redux, React Native Vector Icons, & React Native Elements
+- [React Native Hackathon Starter ★352](https://github.com/dabit3/react-native-hackathon-starter) - React Native Starter Project, great for hackathons or rapid prototyping. Includes tabs, navigation, Redux, React Native Vector Icons, & React Native Elements
 - [🍞 Baker ★46](http://baker.thebakery.io/) - An opinionated MVP toolkit that helps you build mobile apps crazy fast using React Native and Parse Server
-- [react-native-relay-example ★17](https://github.com/sibelius/react-native-relay-example) - React Native working with Relay
-- [react-native-redux ★86](https://github.com/sibelius/react-native-redux) - React Native + Redux + Redux Saga
-- [react-native-boilerplate ★20](https://github.com/pcofilada/react-native-boilerplate) - Simple boilerplate for mobile development using React Native and Redux
-- [react-native-web-workspace ★16](https://github.com/agrcrobles/react-native-web-workspace) - A cross platform app with react in a monorepo
-- [react-native-web-boilerplate ★27](https://github.com/agrcrobles/react-native-web-boilerplate) - A react-native-web stateless hmr boilerplate
-- [native-starter-kit ★1097](https://github.com/start-react/native-starter-kit) - A Starter Kit for React Native + NativeBase + React Navigation + Redux + CodePush Apps (iOS & Android)
-- [react-native-boilerplate-chucknorris ★6](https://github.com/Ali-Ayyad/react-native-boilerplate-chucknorris) - A boilerplate for React Native + React Navigation + React Native Elements (iOS & Android)
+- [react-native-relay-example ★33](https://github.com/sibelius/react-native-relay-example) - React Native working with Relay
+- [react-native-redux ★126](https://github.com/sibelius/react-native-redux) - React Native + Redux + Redux Saga
+- [react-native-boilerplate ★39](https://github.com/pcofilada/react-native-boilerplate) - Simple boilerplate for mobile development using React Native and Redux
+- [react-native-web-workspace ★30](https://github.com/agrcrobles/react-native-web-workspace) - A cross platform app with react in a monorepo
+- [react-native-web-boilerplate ★46](https://github.com/agrcrobles/react-native-web-boilerplate) - A react-native-web stateless hmr boilerplate
+- [native-starter-kit ★1273](https://github.com/start-react/native-starter-kit) - A Starter Kit for React Native + NativeBase + React Navigation + Redux + CodePush Apps (iOS & Android)
+- [react-native-boilerplate-chucknorris ★13](https://github.com/Ali-Ayyad/react-native-boilerplate-chucknorris) - A boilerplate for React Native + React Navigation + React Native Elements (iOS & Android)
 
 ## Libraries
 
 Libraries / SDK type additions for React Native development.
 
-- [Panza ★155](https://github.com/bmcmahen/panza) - a collection of stateless, functional, cross-platform ui components for react-native
-- [React Native Elements ★4303](https://github.com/dabit3/React-Native-Elements) - a collection of React Native UI Elements and components.
-- [Shoutem UI ★1693](https://github.com/shoutem/ui) - a complete UI toolkit for React Native from Shoutem
-- [BlankApp UI ★6](https://github.com/blankapp/ui) - Highly customizable and theming components for React Native
+- [Panza ★208](https://github.com/bmcmahen/panza) - a collection of stateless, functional, cross-platform ui components for react-native
+- [React Native Elements ★8157](https://github.com/dabit3/React-Native-Elements) - a collection of React Native UI Elements and components.
+- [Shoutem UI ★2880](https://github.com/shoutem/ui) - a complete UI toolkit for React Native from Shoutem
+- [BlankApp UI ★30](https://github.com/blankapp/ui) - Highly customizable and theming components for React Native
 
 ## Open Source Apps
 
 Open source React Native apps and other examples.
 - [Bristol Pound](http://blog.scottlogic.com/2017/11/22/developing-bristol-pound-an-open-source-react-native-app.html) - An app for the Bristol Pound, a UK-based local currency.
-- [ASOS ★1](https://github.com/edwinbosire/ASOS) - E-commerce app for ASOS (clone)
-- [Urban Dictionary ★16](https://github.com/edwinbosire/Urbandict) - Mobile implementation of the popular Urban Dictionary website.
-- [Appointments  ★58](https://github.com/iZaL/my-appointment) - Full-fledged ReactNative App for Booking Appointments
-- [GitHub Popular ★1085](https://github.com/crazycodeboy/GitHubPopular) - This is a GitHub most popular repositories viewer with React Native.
-- [NBAreact ★31](https://github.com/jbkuczma/NBAreact)
-- [Reddit made with React Native and Redux ★72](https://github.com/KevinOfNeu/xReddit)
+- [ASOS ★60](https://github.com/edwinbosire/ASOS) - E-commerce app for ASOS (clone)
+- [Urban Dictionary ★48](https://github.com/edwinbosire/Urbandict) - Mobile implementation of the popular Urban Dictionary website.
+- [Appointments  ★94](https://github.com/iZaL/my-appointment) - Full-fledged ReactNative App for Booking Appointments
+- [GitHub Popular ★1824](https://github.com/crazycodeboy/GitHubPopular) - This is a GitHub most popular repositories viewer with React Native.
+- [NBAreact ★60](https://github.com/jbkuczma/NBAreact)
+- [Reddit made with React Native and Redux ★81](https://github.com/KevinOfNeu/xReddit)
 - [React Native Showcase](https://facebook.github.io/react-native/showcase.html)
-- [DuckDuckGo App (Unofficial) ★113](https://github.com/kiok46/duckduckgo)
-- [Hacker News (iOS & Android) ★2747](https://github.com/iSimar/HackerNews-React-Native)
-- [ReactNativeHackerNews ★217](https://github.com/jsdf/ReactNativeHackerNews)
-- [ReactNativeRedditReader ★285](https://github.com/akveo/react-native-reddit-reader)
-- [Premier League ★14](https://github.com/ennioma/react-native-premier-league)
-- [Buyscreen sample ★125](https://github.com/appintheair/react-native-buyscreen)
-- [NewsWatch video viewer ★108](https://github.com/bradoyler/newswatch-react-native)
-- [Native iOS font list ★39](https://github.com/yayolius/react-native-font-list)
-- [Confreaks ★28](https://github.com/cabaret/confreaks-react-native)
-- [iOS Conference App made with React Native ★202](https://github.com/mikkoj/NortalTechDay)
-- [Alt/Flux Demo ★106](https://github.com/mrblueblue/react-native-alt-demo)
-- [Dribbble React Native ★1492](https://github.com/catalinmiron/react-native-dribbble-app)
-- [Lumpen Radio ★141](https://github.com/jhabdas/lumpen-radio)
-- [React Native Embedded App ★171](https://github.com/dsibiski/react-native-embedded-app-example) -A collection of examples for using React Native in an existing iOS application
-- [An example React Native project for client login authentication ★231](https://github.com/ryanmcdermott/react-native-login)
-- [iOS app that transcript your voice with IBM Watson Cloud ★33](https://github.com/yrezgui/meowth-ios)
-- [React Native Chromecast App ★46](https://github.com/holoed/ChromeCast_ReactNative)
-- [React Native Example, Geo and Location ★142](https://github.com/bgryszko/react-native-example)
-- [MagicMirror ★211](https://github.com/ajwhite/MagicMirror)
-- [Kakapo -  ambient sound mixer ★99](https://github.com/bluedaniel/Kakapo-native)
-- [Finance React Native ★1000](https://github.com/7kfpun/FinanceReactNative) - iOS's stocks app clone written in React Native for demo purpose.
-- [Redux Demo ★181](https://github.com/chentsulin/react-native-counter-ios-android) - Minimal implement of redux counter example on ReactNative iOS and Android
-- [react-native-nw-react-calculator ★3472](https://github.com/benoitvallon/react-native-nw-react-calculator) - A mobile, desktop and website App with the same code
+- [DuckDuckGo App (Unofficial) ★205](https://github.com/kiok46/duckduckgo)
+- [Hacker News (iOS & Android) ★3221](https://github.com/iSimar/HackerNews-React-Native)
+- [ReactNativeHackerNews ★231](https://github.com/jsdf/ReactNativeHackerNews)
+- [ReactNativeRedditReader ★323](https://github.com/akveo/react-native-reddit-reader)
+- [Premier League ★20](https://github.com/ennioma/react-native-premier-league)
+- [Buyscreen sample ★144](https://github.com/appintheair/react-native-buyscreen)
+- [NewsWatch video viewer ★124](https://github.com/bradoyler/newswatch-react-native)
+- [Native iOS font list ★55](https://github.com/yayolius/react-native-font-list)
+- [Confreaks ★29](https://github.com/cabaret/confreaks-react-native)
+- [iOS Conference App made with React Native ★224](https://github.com/mikkoj/NortalTechDay)
+- [Alt/Flux Demo ★107](https://github.com/mrblueblue/react-native-alt-demo)
+- [Dribbble React Native ★1775](https://github.com/catalinmiron/react-native-dribbble-app)
+- [Lumpen Radio ★170](https://github.com/jhabdas/lumpen-radio)
+- [React Native Embedded App ★197](https://github.com/dsibiski/react-native-embedded-app-example) -A collection of examples for using React Native in an existing iOS application
+- [An example React Native project for client login authentication ★346](https://github.com/ryanmcdermott/react-native-login)
+- [iOS app that transcript your voice with IBM Watson Cloud ★40](https://github.com/yrezgui/meowth-ios)
+- [React Native Chromecast App ★51](https://github.com/holoed/ChromeCast_ReactNative)
+- [React Native Example, Geo and Location ★188](https://github.com/bgryszko/react-native-example)
+- [MagicMirror ★226](https://github.com/ajwhite/MagicMirror)
+- [Kakapo -  ambient sound mixer ★116](https://github.com/bluedaniel/Kakapo-native)
+- [Finance React Native ★1348](https://github.com/7kfpun/FinanceReactNative) - iOS's stocks app clone written in React Native for demo purpose.
+- [Redux Demo ★213](https://github.com/chentsulin/react-native-counter-ios-android) - Minimal implement of redux counter example on ReactNative iOS and Android
+- [react-native-nw-react-calculator ★4076](https://github.com/benoitvallon/react-native-nw-react-calculator) - A mobile, desktop and website App with the same code
 - [Posters_Galore_Android ★11](https://github.com/marmelab/Posters_Galore_Android) - An experimental Android application using Redux and a REST API
-- [uestc-bbs-react-native ★150](https://github.com/just4fun/uestc-bbs-react-native) - An iOS client for http://bbs.uestc.edu.cn/ written in React Native with Redux
+- [uestc-bbs-react-native ★182](https://github.com/just4fun/uestc-bbs-react-native) - An iOS client for http://bbs.uestc.edu.cn/ written in React Native with Redux
 - [Text Blast ★19](https://github.com/SeshApp/text-blast-react-native) - iOS client for MMS text blasting app with analogous [ionic version](https://github.com/SeshApp/text-blast-ionic) for comparison
-- [iTunesConnect ★35](https://github.com/oney/iTunesConnect) - Unofficial iTunes Connect App
-- [react-native-gitfeed ★1468](https://github.com/xiekw2010/react-native-gitfeed) - Yet another Github client written with react-native(iOS & android)
-- [rndrawer-implemented-rnrouter ★43](https://github.com/efkan/rndrawer-implemented-rnrouter) - A react-native-drawer implemented example and scaffolding for react-native-router-flux
-- [GitterMobile ★119](https://github.com/terrysahaidak/GitterMobile) - Gitter (chat for github) client for iOS and Android
-- [Hello Bemans ★4](https://github.com/rapportyou/HelloBemans) - Health Trainer Connection App (Android Version)
-- [Insta Snap  ★59](https://github.com/iZaL/insta-snap) - Image Sharing App
-- [30-days-of-react-native  ★2381](https://github.com/fangwei716/30-days-of-react-native) - 30 days of React Native examples (inspired by 30DaysofSwift)
-- [Ziliun React Native  ★221](https://github.com/sonnylazuardi/ziliun-react-native) - Wordpress based article reader built with react native
-- [Vocab React Native ★12](https://github.com/thaiinhk/VocabReactNative) - Thai Vocabulary Learning App
-- [React Weather ★338](https://github.com/stage88/react-weather) - A simple weather app built with React Native
-- [react-native-hiapp ★269](https://github.com/BelinChung/react-native-hiapp) - A simple and Twitter like demo app written in react-native
-- [NewYorkTimesTopStories ★11](https://github.com/vidyuthd/NYTimesTopStories-React-Native) - Read Topstories of NewYorkTimes using its api written for android in react-native.
-- [react-native-redux-facebook ★58](https://github.com/bkspace/react-native-redux-facebook) - A simple React Redux Facebook authentication demo app.
-- [reading ★1457](https://github.com/attentiveness/reading) - Reading App Write In React-Native.
-- [HackerWeb ★100](https://github.com/cheeaun/hackerweb-native) - A simply readable Hacker News web app for iOS & Android.
-- [Luno ★215](https://github.com/alwx/luno-react-native) - A ClojureScript React Native app demonstration
-- [BBC News (Unofficial) ★135](https://github.com/joeltrew/BBCNews-React-Native) - a BBC news app
-- [Assemblies ★221](https://github.com/buildreactnative/assemblies) - a Meetup clone
+- [iTunesConnect ★46](https://github.com/oney/iTunesConnect) - Unofficial iTunes Connect App
+- [react-native-gitfeed ★1632](https://github.com/xiekw2010/react-native-gitfeed) - Yet another Github client written with react-native(iOS & android)
+- [rndrawer-implemented-rnrouter ★48](https://github.com/efkan/rndrawer-implemented-rnrouter) - A react-native-drawer implemented example and scaffolding for react-native-router-flux
+- [GitterMobile ★235](https://github.com/terrysahaidak/GitterMobile) - Gitter (chat for github) client for iOS and Android
+- [Hello Bemans ★5](https://github.com/rapportyou/HelloBemans) - Health Trainer Connection App (Android Version)
+- [Insta Snap  ★87](https://github.com/iZaL/insta-snap) - Image Sharing App
+- [30-days-of-react-native  ★3787](https://github.com/fangwei716/30-days-of-react-native) - 30 days of React Native examples (inspired by 30DaysofSwift)
+- [Ziliun React Native  ★252](https://github.com/sonnylazuardi/ziliun-react-native) - Wordpress based article reader built with react native
+- [Vocab React Native ★19](https://github.com/thaiinhk/VocabReactNative) - Thai Vocabulary Learning App
+- [React Weather ★528](https://github.com/stage88/react-weather) - A simple weather app built with React Native
+- [react-native-hiapp ★416](https://github.com/BelinChung/react-native-hiapp) - A simple and Twitter like demo app written in react-native
+- [NewYorkTimesTopStories ★15](https://github.com/vidyuthd/NYTimesTopStories-React-Native) - Read Topstories of NewYorkTimes using its api written for android in react-native.
+- [react-native-redux-facebook ★77](https://github.com/bkspace/react-native-redux-facebook) - A simple React Redux Facebook authentication demo app.
+- [reading ★2335](https://github.com/attentiveness/reading) - Reading App Write In React-Native.
+- [HackerWeb ★135](https://github.com/cheeaun/hackerweb-native) - A simply readable Hacker News web app for iOS & Android.
+- [Luno ★246](https://github.com/alwx/luno-react-native) - A ClojureScript React Native app demonstration
+- [BBC News (Unofficial) ★172](https://github.com/joeltrew/BBCNews-React-Native) - a BBC news app
+- [Assemblies ★284](https://github.com/buildreactnative/assemblies) - a Meetup clone
 - [Instagram clone](https://github.com/reindexio/reindex-examples/tree/master/react-native-gallery) - an Instagram clone
-- [TaskRabbit's Sample App ★460](https://github.com/taskrabbit/ReactNativeSampleApp) - a testing ground for Task Rabbit's app making
-- [react-native-sudoku ★391](https://github.com/nihgwu/react-native-sudoku) - a sudoku game written in React Native
-- [react-native-otello ★4](https://github.com/hiaw/react_native_otello) - a reversi game written in React Native
-- [Look Lock ★79](https://github.com/7kfpun/PhotosReactNative) - An app for showing photos without worries.
-- [react-native-basketball ★243](https://github.com/FaridSafi/react-native-basketball) - a clone of the Facebook Basketball game
-- [Finance MacOS React Native ★57](https://github.com/7kfpun/FinanceMacOSReactNative) - iOS's Stocks App clone written for MacOS with Touch Bar support. Data is pulled from Yahoo Finance.
-- [YouTrack Mobile ★46](https://github.com/JetBrains/youtrack-mobile) – a client for YouTrack – issue tracker from JetBrains.
-- [QRCode App ★8](https://github.com/insiderdev/react-native-qrcode-app) - application for scanning and generating QR codes.
-- [Sequent ★15](https://github.com/sobstel/sequent) - short-term memory training game (W/ Redux).
-- [RNV2ex ★2](https://github.com/dyygtfx/RNV2ex) - react-native for v2ex
-- [Paramap ★1](https://github.com/twist900/paramap) - Accessability map. React-native with Redux and Firebase. iOS and Android.
-- [Surmon.me.native](https://github.com/surmon-china/surmon.me.native) A react-native applaction for surmon.me
-- [AudienceNetworkReactNative ★36](https://github.com/7kfpun/AudienceNetworkReactNative) - Facebook Audience Network Performance Tool.
-- [SoundcloudMboX ★1](https://github.com/trazyn/SoundcloudMboX) SoundcloudMobX is the Soundcloud for iOS, Build with React-Native and MobX.
-- [MoeFM ★0](https://github.com/codeestX/MoeFM) - A light MusicPlayer build with React Native & Redux for both Android and iOS.
-- [what the thing? ★256](https://github.com/vigzmv/what_the_thing) - Point camera at things to learn how to say them in a different language.
-- [live translator ★4](https://github.com/agrcrobles/react-native-live-translator) - An app that translates in real time what you see from your mobile.
-- [GitPoint ★1785](https://github.com/gitpoint/git-point) - A mobile GitHub client for both iOS and Android.
-- [PxView ★42](https://github.com/alphasp/pxview) - An unofficial Pixiv app client for Android and iOS
-- [Todo List ★2](https://github.com/rishabhbhatia/react-native-todo) - Todo-List app using SwipeView with ES6 standards for iOS and Android.
+- [TaskRabbit's Sample App ★670](https://github.com/taskrabbit/ReactNativeSampleApp) - a testing ground for Task Rabbit's app making
+- [react-native-sudoku ★482](https://github.com/nihgwu/react-native-sudoku) - a sudoku game written in React Native
+- [react-native-otello ★5](https://github.com/hiaw/react_native_otello) - a reversi game written in React Native
+- [Look Lock ★115](https://github.com/7kfpun/PhotosReactNative) - An app for showing photos without worries.
+- [react-native-basketball ★343](https://github.com/FaridSafi/react-native-basketball) - a clone of the Facebook Basketball game
+- [Finance MacOS React Native ★76](https://github.com/7kfpun/FinanceMacOSReactNative) - iOS's Stocks App clone written for MacOS with Touch Bar support. Data is pulled from Yahoo Finance.
+- [YouTrack Mobile ★103](https://github.com/JetBrains/youtrack-mobile) – a client for YouTrack – issue tracker from JetBrains.
+- [QRCode App ★46](https://github.com/insiderdev/react-native-qrcode-app) - application for scanning and generating QR codes.
+- [Sequent ★35](https://github.com/sobstel/sequent) - short-term memory training game (W/ Redux).
+- [RNV2ex ★3](https://github.com/dyygtfx/RNV2ex) - react-native for v2ex
+- [Paramap ★19](https://github.com/twist900/paramap) - Accessability map. React-native with Redux and Firebase. iOS and Android.
+- [Surmon.me.native ★282](https://github.com/surmon-china/surmon.me.native) A react-native applaction for surmon.me
+- [AudienceNetworkReactNative ★48](https://github.com/7kfpun/AudienceNetworkReactNative) - Facebook Audience Network Performance Tool.
+- [SoundcloudMboX ★33](https://github.com/trazyn/SoundcloudMboX) SoundcloudMobX is the Soundcloud for iOS, Build with React-Native and MobX.
+- [MoeFM ★25](https://github.com/codeestX/MoeFM) - A light MusicPlayer build with React Native & Redux for both Android and iOS.
+- [what the thing? ★344](https://github.com/vigzmv/what_the_thing) - Point camera at things to learn how to say them in a different language.
+- [live translator ★57](https://github.com/agrcrobles/react-native-live-translator) - An app that translates in real time what you see from your mobile.
+- [GitPoint ★2875](https://github.com/gitpoint/git-point) - A mobile GitHub client for both iOS and Android.
+- [PxView ★110](https://github.com/alphasp/pxview) - An unofficial Pixiv app client for Android and iOS
+- [Todo List ★9](https://github.com/rishabhbhatia/react-native-todo) - Todo-List app using SwipeView with ES6 standards for iOS and Android.
 - [Quick-Sample ★2](https://github.com/innFactory/react-native-quick-sample) - A small and simple example app with navigation, data persistence, redux, listview and animation.
-- [Buttercup Mobile ★41](https://github.com/buttercup/buttercup-mobile) - Mobile password manager
+- [Buttercup Mobile ★44](https://github.com/buttercup/buttercup-mobile) - Mobile password manager
 
 ## Frameworks
 
-- [Awesome React Native Meteor ★115](https://github.com/meteor-factory/awesome-react-native-meteor) - An awesome list of resources for using Meteor and React Native together
-- [NativeBase ★3679](https://github.com/GeekyAnts/NativeBase) - builds a layer on top of React Native that provides you with basic set of components for mobile application development
-- [React Native Diagnose](https://github.com/netbeast/react-native-diagnose) -  A framework to test a React Native app during runtime and production
-- [Teaset ★215](https://github.com/rilyu/teaset) - A UI library for react native, provides 20+ pure JS(ES6) components, focusing on content display and action control.
+- [Awesome React Native Meteor ★145](https://github.com/meteor-factory/awesome-react-native-meteor) - An awesome list of resources for using Meteor and React Native together
+- [NativeBase ★6855](https://github.com/GeekyAnts/NativeBase) - builds a layer on top of React Native that provides you with basic set of components for mobile application development
+- [React Native Diagnose ★5](https://github.com/netbeast/react-native-diagnose) -  A framework to test a React Native app during runtime and production
+- [Teaset ★521](https://github.com/rilyu/teaset) - A UI library for react native, provides 20+ pure JS(ES6) components, focusing on content display and action control.
 
 ## Tutorials
 
@@ -1052,12 +1050,12 @@ Walkthroughs and tutorials that help you learn React Native.
 - [Enabling Live Reload](https://www.reddit.com/r/reactnative/comments/30hbg3/enabling_live_reload/)
 - [Facebook's F8 App Walkthrough Tutorial: React Native, Redux, Relay, Flow, Jest](http://makeitopen.com/)
 - [Facebook Login With React Native](http://brentvatne.ca/facebook-login-with-react-native)
-- [Fully-immersive, hands-on, and fun learning experience for React Native ★537](https://github.com/jondot/ReactNativeKatas)
+- [Fully-immersive, hands-on, and fun learning experience for React Native ★672](https://github.com/jondot/ReactNativeKatas)
 - [Integrating Parse and React Native for iOS](http://www.raywenderlich.com/106369/integrating-parse-react-native-ios)
 - [Introducing React Native (on Ray Wenderlich's)](http://www.raywenderlich.com/99473/introducing-react-native-building-apps-javascript)
 - [Leverage Existing iOS Views In Your React Native App](http://moduscreate.com/leverage-existing-ios-views-react-native-app/)
 - [Official React Native tutorial](http://facebook.github.io/react-native/docs/tutorial.html#content)
-- [React Native Android Widget Proof of Concept](https://github.com/netbeast/react-native-android-widget-poc)
+- [React Native Android Widget Proof of Concept ★54](https://github.com/netbeast/react-native-android-widget-poc)
 - [React Native Periscope Hearts Animation](http://browniefed.com/blog/2015/09/07/react-native-periscope-hearts-animation/)
 - [React Native Youtube Animated Video Slide](http://browniefed.com/blog/2015/08/31/react-native-youtube-animated-video-slide/)
 - [React Native and Socket.io](https://bullpen.bullish.io/how-to-actually-use-socket-io-in-react-native-39082d8d6172)
@@ -1067,7 +1065,7 @@ Walkthroughs and tutorials that help you learn React Native.
 - [React-native Animated ScrollView Row Swipe Actions](http://browniefed.com/blog/2015/08/01/react-native-animated-listview-row-swipe/)
 - [React-native press and hold button actions](http://browniefed.com/blog/2015/08/22/react-native-press-and-hold-button-actions/)
 - [React Native Express](http://www.reactnativeexpress.com/)
-- [React Native with Django backend ★3](https://github.com/shunpochang/connect_love_mobile_demo)
+- [React Native with Django backend ★8](https://github.com/shunpochang/connect_love_mobile_demo)
 - [Simple React Native forms with redux-form, immutable.js and styled-components](http://esbenp.github.io/2017/01/06/react-native-redux-form-immutable-styled-components/)
 - [The beauty of react-native -Build a stunning wallpaper app](https://www.smashingmagazine.com/2016/04/the-beauty-of-react-native-building-your-first-ios-app-with-javascript-part-1/)
 
@@ -1095,7 +1093,7 @@ Assortment of conference and training videos.
 
 ### Talks
 
-- [awesome-react-native-talks ★194](https://github.com/mightyCrow/awesome-react-native-talks) - A curated list of talks about React Native or topics related to React Native.
+- [awesome-react-native-talks ★262](https://github.com/mightyCrow/awesome-react-native-talks) - A curated list of talks about React Native or topics related to React Native.
 - React Conf 2015: [Introducing React Native](https://youtu.be/KVZ-P-ZI6W4)
 - React Conf 2015: [A Deep Dive into React Native](https://youtu.be/7rDsRXj9-cU)
 - F8 2015: [React Native and Relay](https://www.youtube.com/watch?v=X6YbAKiLCLU)
@@ -1113,7 +1111,7 @@ Assortment of conference and training videos.
 - Udemy.com: [Build apps with React Native](https://www.udemy.com/reactnative/learn/v4/overview)
 - [React Native training ★238](https://www.gitbook.com/book/unbug/react-native-training/details)
 - Dailydrip.com: [Learn React Native in 5min per day](https://www.dailydrip.com/topics/react-native/)
-- [Awesome React Native Education ★106](https://github.com/hsavit1/Awesome-React-Native-Education)
+- [Awesome React Native Education ★326](https://github.com/hsavit1/Awesome-React-Native-Education)
 - [Mario Díez Channel](https://www.youtube.com/channel/UCisGMoxaVxJMcbio2FBHORg/search?query=React+Native) - Youtube channel in spanish about with a series of videos talking about react native
 - Udemy.com: [Create Your First React Native App](https://www.udemy.com/create-your-first-react-native-app/?couponCode=AWESOME-REACT-NATIVE) - Introduction to building a React Native app and learning the foundational pieces.
 - Handlebarlabs.com: [Learn React Native + Meteor](http://reactnativemeteor.com) - Comprehensive course & community on building an application with React Native and Meteor.

--- a/validate.rb
+++ b/validate.rb
@@ -7,7 +7,13 @@ require 'httparty'
 
 def check_link(uri)
   HTTParty.head(uri, :verify => false).code.to_i.tap do |status|
-    raise "Request had status #{status}" if (400..422).include?(status)
+    if (400..422).include?(status)
+      if status != 403 && !uri.exclude?('udemy.com')
+        raise "Request had status #{status}"
+      else
+        putc('S')
+      end
+    end
   end
 end
 


### PR DESCRIPTION
e.g. you can test by validating the last 15 links by adding this code in line 26 of `validate.rb`.
(before `puts "Validating #{links.size} links..."`)

```
links = links.last(15)
```

output:
```
$ bundle exec ruby validate.rb
Validating 15 links...
.S.............%
```