### PR TITLE
fix(build): skip udemy links validation if they return 403 http status

### DIFF
--- a/validate.rb
+++ b/validate.rb
@@ -7,7 +7,13 @@ require 'httparty'
 
 def check_link(uri)
   HTTParty.head(uri, :verify => false).code.to_i.tap do |status|
-    raise "Request had status #{status}" if (400..422).include?(status)
+    if (400..422).include?(status)
+      if status != 403 && !uri.exclude?('udemy.com')
+        raise "Request had status #{status}"
+      else
+        putc('S')
+      end
+    end
   end
 end
 


### PR DESCRIPTION
e.g. you can test by validating the last 15 links by adding this code in line 26 of `validate.rb`.
(before `puts "Validating #{links.size} links..."`)

```
links = links.last(15)
```

output:
```
$ bundle exec ruby validate.rb
Validating 15 links...
.S.............%
```