### PR TITLE
Add Rocket.Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,7 @@ Open source React Native apps and other examples.
 * [Alt/Flux Demo ★107](https://github.com/mrblueblue/react-native-alt-demo)
 * [Appointments ★104](https://github.com/iZaL/my-appointment) - Full-fledged ReactNative App for Booking Appointments
 * [Insta Snap ★98](https://github.com/iZaL/insta-snap) - Image Sharing App
+* [Rocket.Chat ★92](https://github.com/RocketChat/Rocket.Chat.ReactNative) - Open Source Team Communication
 * [Finance MacOS React Native ★83](https://github.com/7kfpun/FinanceMacOSReactNative) - iOS's Stocks App clone written for MacOS with Touch Bar support. Data is pulled from Yahoo Finance.
 * [Reddit made with React Native and Redux ★82](https://github.com/KevinOfNeu/xReddit)
 * [live translator ★79](https://github.com/agrcrobles/react-native-live-translator) - An app that translates in real time what you see from your mobile.


### PR DESCRIPTION
This is an experimental version of Rocket.Chat built on React Native.

Google Play: https://play.google.com/store/apps/details?id=chat.rocket.reactnative
App Store: _soon_