### PR TITLE
Add Chain React

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ dotan-at-paracode.com.
 
 
 - [Conferences](#conferences)
+  - [Chain React - Portland, OR USA](#chain-react---portland-or-usa)
   - [React Native EU - Wroclaw, Poland](#react-native-eu---wroclaw-poland)
   - [React Alicante - Alicante, Spain](#react-alicante---alicante-spain)
   - [ReactNext - Tel Aviv, Israel](#reactnext---tel-aviv-israel)
@@ -127,6 +128,12 @@ list](https://github.com/jondot/awesome-react-native/graphs/contributors)\:)
 Conferences dedicated to React Native specifically. A listing of React
 general conferences can be found on the [ReactJS
 site](https://facebook.github.io/react/docs/conferences.html).
+
+### Chain React - Portland, OR USA
+http://chainreactconf.com
+
+Workshops - July 11th, 2018\
+Conference - July 12-13th, 2018
 
 ### React Native EU - Wroclaw, Poland
 http://react-native.eu/


### PR DESCRIPTION
Even though Chain React is already done for the year, the talks are linked from the website, and we'll be doing it again next year around the same time period.