### PR TITLE
Remove Spectrum from open source apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,7 +1270,6 @@ Open source React Native apps and other examples.
 * [Forex Rates](https://github.com/MicroPyramid/forex-rates-mobile-app) - Foreign exchange rates. currency rate converter. Historical exchange rates. Android and iOS.
 * [Smog Alert App](https://github.com/Bartozzz/smog-alert-app) – provides real-time air pollution data all around the world and shows nearby polluters.
 * [Audio Book App](https://github.com/minhtc/sachnoiapp) – Completed Audiobook app with some cool animations.
-* [Spectrum](https://github.com/withspectrum/spectrum/tree/alpha/mobile) - The community platform for the future.
 * [FastBuy](https://github.com/Bruno-Furtado/fastbuy-app) - App to manage the products from a dummy Store (built with React Native and Redux).
 * [Hydropuzzle](https://github.com/hydropuzzle/hydropuzzle) - Stylish puzzle adventure game.
 


### PR DESCRIPTION
Spectrum decided to remove their mobile app from the repository (for now).

[https://github.com/withspectrum/spectrum/commit/4be7b7fe4248bf3b8071d507fe18a227a022a4c1](https://github.com/withspectrum/spectrum/commit/4be7b7fe4248bf3b8071d507fe18a227a022a4c1)