### PR TITLE
Add extension category and react-native-today-widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotan-at-paracode.com.
         - [Integrations](#integrations)
         - [Monetization](#monetization)
         - [Animation](#animation)
+        - [Extension](#extension)
         - [Other Platforms](#other-platforms)
     - [Utilities](#utilities)
     - [Seeds](#seeds)
@@ -1094,6 +1095,11 @@ Components and native modules.
 * [react-native-gl-model-view ★210](https://github.com/rastapasta/react-native-gl-model-view) - Display and animate textured Wavefront .OBJ 3D models with 60fps (iOS)
 * [react-native-animated-sprite ★104](https://github.com/micahrye/react-native-animated-sprite) - A feature rich declarative component for animation, tweening, and dragging sprites.
 
+### Extension
+
+* [React Native Android Widget Proof of Concept ★127](https://github.com/netbeast/react-native-android-widget-poc) - Android Widget Proof of Concept in React Native
+* [React Native Today Widget ★190](https://github.com/matejkriz/react-native-today-widget) - iOS Today Widget Extension in React Native
+
 ### Other Platforms
 
 * [react-native-macos ★10453](http://github.com/ptmt/react-native-macos) - React Native for OS X
@@ -1305,7 +1311,6 @@ Open source React Native apps and other examples.
 Walkthroughs and tutorials that help you learn React Native.
 
 * [Fully-immersive, hands-on, and fun learning experience for React Native ★825](https://github.com/jondot/ReactNativeKatas)
-* [React Native Android Widget Proof of Concept ★110](https://github.com/netbeast/react-native-android-widget-poc)
 * [React Native with Django backend ★12](https://github.com/shunpochang/connect_love_mobile_demo)
 * [Setting up background tasks that run periodically when app is closed in React Native](https://hackernoon.com/easy-os-background-tasks-in-react-native-bc4476c48b8a)
 * [Animate React Native UI Elements](https://egghead.io/courses/animate-react-native-ui-elements)


### PR DESCRIPTION
Hi @jondot thanks for your helpful repository.

I added [react-native-today-widget](https://github.com/matejkriz/react-native-today-widget) library.

I don't know why there is not this repository here.

Additionally, I added extension category and move [react-native-android-widget-poc](https://github.com/netbeast/react-native-android-widget-poc) library from tutorial category to extension category.

thanks.