### PR TITLE
Turned off dead links test on PR

### DIFF
--- a/celeste-config-pr.js
+++ b/celeste-config-pr.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     plugins: {
         dedupLinks: true,
-        brokenLinks: true,
+        brokenLinks: false,
         sortByStars: true,
     }
 }


### PR DESCRIPTION
Hi @jondot , 

I think this repo should keep going, but testing dead links in every PR is blocking almost every new contribution.

Tests sometimes fail even if links are fine, I guess some extra attempts can solve the problem.

I propose to remove broken links on PR and leave this as periodic check, so people can still contribute.