### PR TITLE
Add Square In-App Payments SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ Components and native modules.
 * [react-native-revmob ★15](https://github.com/RevMob/react-native-revmob) - RevMob wrapper for React Native.
 * [react-native-google-pay ★2](https://github.com/busfor/react-native-google-pay) - Accept Payments with Google Pay for React Native apps.
 * [react-native-apay ★2](https://github.com/busfor/react-native-apay) - React Native bridge for Apple Pay
+* [react-native-square-in-app-payments ★18](https://github.com/square/in-app-payments-react-native-plugin) - Square React Native plugin for In-App Payments SDK.
 
 ### Animation
 


### PR DESCRIPTION
This PR adds the [Square React Native plugin](https://github.com/square/in-app-payments-react-native-plugin) for [Square In-App Payments SDK](https://squareup.com/developers/in-app-payments).

