### PR TITLE
add agora-react-native-rtm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,7 @@ Components and native modules.
 * [react-native-heyzap](https://github.com/react-native-contrib/react-native-heyzap)- Heyzap plugin for React Native
 * [react-native-launch-navigator](https://github.com/dpa99c/react-native-launch-navigator) - React Native module to launch popular navigation/ride apps from a single API (Android & iOS)
 * [react-native-agora +190](https://github.com/syanbo/react-native-agora) - A React Native Agora WebRTC Wrapper.
+* [agora-react-native-rtm +5](https://github.com/agoraio/agora-react-native-rtm) - A React Native Agora RealTime-Message Cloud Service Wrapper.
 
 ### Monetization
 


### PR DESCRIPTION
This PR adds the [**Real time Messaging**](https://github.com/agoraio/agora-react-native-rtm) React Native plugin for [**Agora RTM SDK**](https://docs.agora.io/en/Real-time-Messaging/RTM_product?platform=All%20Platforms).

