### PR TITLE
Rename react-hook-hooked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,7 +1238,7 @@ Useful React Native tooling.
 * [React Native Playground](https://rnplay.org/) - Run React Native apps in your browser via real time simulator
 * [exponent](https://expo.io/) - Use React Native without XCode (a previewer app + local server infrastructure)
 * [Deco IDE](https://www.decosoftware.com/) - React Native IDE with components manager
-* [react-hook-hooker](https://github.com/fjcaetano/react-hook-hooker) - A nifty little HOC to add hooks to your React components.
+* [react-hook-hooked](https://github.com/fjcaetano/react-hook-hooked) - A nifty little HOC to add hooks to your React components.
 
 ## Seeds
 


### PR DESCRIPTION
Republished the library under a less controversial name:

https://github.com/fjcaetano/react-hook-hooked