### PR TITLE
Add react-native-use-persist-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ Components and native modules.
 * [react-native-fluxbone ★5](https://github.com/jgable/react-native-fluxbone) - A group of libraries that help with the FluxBone pattern in React Native
 * [react-native-cross-settings ★5](https://github.com/aMarCruz/react-native-cross-settings) - React Native Settings module for both Android & iOS.
 * [react-native-HsvToRgb ★3](https://github.com/Copypeng/react-native-HsvToRgb) - a helper to convert HSV(HSB) color to RGB.
+* [react-native-use-persist-storage ★3](https://github.com/visuallylab/react-native-use-persist-storage) - Persist and rehydrate your context(state) using React Hooks
 * [react-native-tools ★0](https://github.com/kkennis/react-native-tools) - Tools for react native project development
 * [react-native-call-observer](https://github.com/liamse/react-native-call-observer) - Helps to observe call status like incoming, ended, and connected (iOS).
 * [react-native-iphone-se-helper ★0](https://github.com/heyman333/react-native-iphone-se-helper) - utils for developing iphone SE size.


### PR DESCRIPTION
<!--
https://github.com/visuallylab/react-native-use-persist-storage
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->

[react-native-use-persist-storage](https://github.com/visuallylab/react-native-use-persist-storage)
An easy way use persist storage using react hooks.
- persist storage([Async Storage](https://github.com/react-native-community/react-native-async-storage))
- easy use for react hooks
- support migration & sensitive info


