### PR TITLE
Add react-native-media-clipboard to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ Components and native modules.
 * [react-native-barcode-scanner ★60](https://github.com/lifuzu/ReactNativeBarcodeScanner) - Barcode scanner for React Native
 * [react-native-haptic-feedback ★60](https://github.com/mkuczera/react-native-haptic-feedback) - Trigger Haptic Native Feedback on iOS and Android
 * [react-native-clipboard ★58](https://github.com/silentcloud/react-native-clipboard) - React Native component for getting or setting clipboard content
+* [react-native-media-clipboard](https://github.com/Jarred-Sumner/react-native-media-clipboard) - React Native module for getting images, URLs, and strings from the clipboard
 * [react-native-nfc-ios ★52](https://github.com/barodeur/react-native-nfc-ios) - Easy to use CoreNFC for React Native
 * [react-native-android-sms ★48](https://github.com/msmakhlouf/react-native-android-sms) - A react native android module to list/send sms.
 * [react-native-voip-push-notification ★48](https://github.com/ianlin/react-native-voip-push-notification) - iOS prioritized VoIP Push Notification


### PR DESCRIPTION
<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->

`react-native-media-clipboard` lets you get an image the user has copied to the clipboard. 

Repo: https://github.com/Jarred-Sumner/react-native-media-clipboard

<img src="https://user-images.githubusercontent.com/709451/74530954-3b22d200-4ee0-11ea-85f7-011fda07cd68.png" height=300 />

