### PR TITLE
update newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1519,9 +1519,8 @@ Assortment of conference and training videos.
 
 ## Newsletters
 
-* [Let's React](http://letsreact.io)
+* [React Native Now](https://reactnativenow.com)
 * [React Native Newsletter](http://reactnative.cc)
-* [React Native Coach](http://reactnativecoach.com)
 
 ## Releases
 


### PR DESCRIPTION
Let's React and React Native Coach are now called React Native Now

<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->

https://reactnativenow.com/

