### PR TITLE
Add react-native-anchor-point. Currently, there is not public API in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ Components and native modules.
 * [react-native-custom-picker ★15](https://github.com/budiadiono/react-native-custom-picker) - React native customizable picker component.
 * [react-native-confirmation-code-field ★15](https://github.com/retyui/react-native-confirmation-code-field) - A React Native component to input confirmation code for both Android and IOS
 * [react-native-android-circles ★14](https://github.com/kwaak/react-native-android-circles) - A react native android package to show a circle progress view.
+* [react-native-anchor-point ★14](https://github.com/sueLan/react-native-anchor-point) - Make the fancy 3D transform easier in react native
 * [react-native-code-verification ★13](https://github.com/danchokobo/react-native-code-verification) - An UI module for user-side pincode verification.
 * [react-native-hijri-date-picker ★13](https://github.com/Codelabsys/react-native-hijri-date-picker-android) - Date Picker Dialog for Hijri calendar for android.
 * [react-native-imagewand ★13](https://github.com/NorthFoxz/react-native-imagewand) - image wand for react native


### PR DESCRIPTION
## Why adding this? 
1. Currently, there is no public API in react-native providing the ability to set `transformOrigin`. So you will find it is difficult to do some fancy 3D transform animations. For exmaple, [cube animation](https://www.npmjs.com/package/react-native-cube-transition) has some flaws. 
    - There is a gap between the views when translating views in Android 
    - The angle is not correct, less than 90 degrees, make the animation wired. It is not a cube, if you try to adjust the angle, you will break all the things. 
    - part of the view is clipped, not rendering on the screen. 
![image2020-5-27_17-17-21](https://user-images.githubusercontent.com/7471672/84166299-4c06dd00-aaa7-11ea-8c48-4e401c756767.png)

      Actually, I use this function to solve all these issues. But it is code for company, I can't make it public. The key thing is to set anchor point as (1, 0.5) for the left view and (0, 0.5) for the right view. 
![image](https://user-images.githubusercontent.com/7471672/84166384-63de6100-aaa7-11ea-8102-9de5bee4cf18.png)

2. Beside, for this animation  [foldview-in-react-native](https://commitocracy.com/implementing-foldview-in-react-native-e970011f98b8), one of the most import things is to use [`transformOrigin`](https://github.com/jmurzy/react-native-foldview/blob/892f89569cd851867602ce7412852515dccc7e5f/src/transformUtil.js#L3). 
But, this function works with `transform matrix`, and isn't easy to use. So, I made `react-native-anchor-point`. It looks simple and tricky, but actually very powerful.  With it, you can use the transform API in react-native to achieve many fancy animations.

<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->
https://github.com/sueLan/react-native-anchor-point

