### PR TITLE
Adding react-native-rating-element in list

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Components and native modules.
 * [react-native-popover-haobtc ★514](https://github.com/jeanregisser/react-native-popover) - A component for react-native
 * [react-native-dropdown ★507](https://github.com/alinz/react-native-dropdown) - A better Select dropdown menu for react-native
 * [react-native-star-rating ★489](https://github.com/djchie/react-native-star-rating) - A React Native component for generating and displaying interactive star ratings
+* [react-native-rating-element ★8](https://github.com/ui-ninja/react-native-rating-element) - A react native rating system supporting: decimal point's rating, direction aware icons like bottom to top or right to left etc, custom icons from Ionicons, custom images and record rating given by users.
 * [react-native-parallax ★479](https://github.com/oblador/react-native-parallax) - Parallax effects for React Native using Animated API
 * [react-native-sketch ★467](https://github.com/jgrancher/react-native-sketch) - A react-native &lt;Sketch /> component to draw with touch events.
 * [react-native-dialogs ★463](https://github.com/aakashns/react-native-dialogs) - React Native wrappers for <https://github.com/afollestad/material-dialogs>


### PR DESCRIPTION
I created an open source library for setting up "Rating System" in your mobile app. 
It supports:
decimal point ratings, direction aware like bottom to top or RTL etc, custom icons and images and record ratings given by user.

[react-native-rating-element](https://github.com/ui-ninja/react-native-rating-element)

Thank you 🙏🏻

<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->


