### PR TITLE
add intercom native

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,7 @@ Components and native modules.
 * [react-native-realtimestorage-ios ★8](https://github.com/realtime-framework/RCTRealtimeCloudStorage) - The Realtime Framework Cloud Storage client for React-Native
 * [react-native-axmall-alipay ★7](https://github.com/szq4119/react-native-alipay) - react-native alipay
 * [react-native-youtube-oauth ★7](https://github.com/indatawetrust/react-native-youtube-oauth) - react-native interface to login to youtube (iOS)
+* [react-native-intercom-native ★7](https://github.com/mateioprea/react-native-intercom) - native based Intercom implementation for React Native
 * [react-native-hawk ★5](https://github.com/andyscott/react-native-hawk) - Hawk wrapper for react-native
 * [react-native-sumup ★5](https://github.com/APSL/react-native-sumup) - A React Native implementation of SumupSDK.
 * [react-native-instagram ★5](https://github.com/watzak/react-native-instagram) - react-native instagram wrapper api (iOS)


### PR DESCRIPTION
<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->
Here I've added another one native-based Intercom implementation for React Native. Here is the [link](https://github.com/mateioprea/react-native-intercom).

