### PR TITLE
Add 2 Open source apps & add stars to some open source apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,7 @@ Open source React Native apps and other examples.
 * [QRCode App ★74](https://github.com/insiderdev/react-native-qrcode-app) - application for scanning and generating QR codes.
 * [Nearby Live ★72](https://github.com/N3TC4T/Nearby-Live) - An unofficial NearbyLive app for Android and iOS
 * [SoundcloudMboX ★67](https://github.com/trazyn/SoundcloudMboX) SoundcloudMobX is the Soundcloud for iOS, Build with React-Native and MobX.
+* [React Native Expo examples ★67](https://github.com/robinhuy/react-native-expo-examples) - Learn React Native (Expo CLI) by examples.
 * [Native iOS font list ★60](https://github.com/yayolius/react-native-font-list)
 * [React Native Chromecast App ★56](https://github.com/holoed/ChromeCast_ReactNative)
 * [MoeFM ★54](https://github.com/codeestX/MoeFM) - A light MusicPlayer build with React Native & Redux for both Android and iOS.
@@ -1466,6 +1467,7 @@ Open source React Native apps and other examples.
 * [Art Museum](https://github.com/pedrobern/react-native-art-museums-app) - Browse through the endless Harvard's Art Museum collection.
 * [NMF.earth ★14](https://github.com/NotMyFaultEarth/nmf-app) - Calculate, understand and reduce your carbon footprint. Available for Android and iOS, using Expo, Redux Toolkit and Typescript.
 * [Nyxo ★12](https://github.com/hello-nyxo/nyxo-app) - Sleep tracker and sleep coaching app. Available for Android and iOS.
+* [React Native Typescript examples ★12](https://github.com/robinhuy/react-native-typescript-examples) - Learn React Native by examples.
 * [Post Card App ★1](https://github.com/adarsh0d/postcardApp) - Create old style post card and share on whatsapp as image. Built with Expo and available for android.
 
 

--- a/README.md
+++ b/README.md
@@ -1352,24 +1352,26 @@ Libraries / SDK type additions for React Native development.
 
 Open source React Native apps and other examples.
 
-* [Artsy](https://github.com/artsy/eigen) - The mobile app for [artsy.net](https://artsy.net). Discover fine Art. The Art world in your Pocket.
+* [Joplin ★24100](https://github.com/laurent22/joplin/tree/master/ReactNativeClient) - A note taking app for desktop, CLI, and mobile (linked here is the mobile app).
 * [f8app ★13070](https://github.com/fbsamples/f8app) - Official F8 (Facebook Developer Conference) app of 2017. See [blog post](http://makeitopen.com/blog/2017/12/04/blog-post-f82017-open-source.html).
 * [30-days-of-react-native ★5192](https://github.com/fangwei716/30-days-of-react-native) - 30 days of React Native examples (inspired by 30DaysofSwift)
 * [react-native-nw-react-calculator ★4624](https://github.com/benoitvallon/react-native-nw-react-calculator) - A mobile, desktop and website App with the same code
 * [GitPoint ★3833](https://github.com/gitpoint/git-point) - A mobile GitHub client for both iOS and Android.
 * [Hacker News (iOS & Android) ★3460](https://github.com/iSimar/HackerNews-React-Native)
 * [reading ★2947](https://github.com/attentiveness/reading) - Reading App Write In React-Native.
+* [Artsy ★2786](https://github.com/artsy/eigen) - The mobile app for [artsy.net](https://artsy.net). Discover fine Art. The Art world in your Pocket.
 * [Status.im ★2470](https://github.com/status-im/status-react) - Ethereum client.
 * [GitHub Popular ★2452](https://github.com/crazycodeboy/GitHubPopular) - This is a GitHub most popular repositories viewer with React Native.
 * [Dribbble React Native ★1927](https://github.com/catalinmiron/react-native-dribbble-app)
 * [react-native-gitfeed ★1709](https://github.com/xiekw2010/react-native-gitfeed) - Yet another Github client written with react-native(iOS & android)
 * [Finance React Native ★1680](https://github.com/7kfpun/FinanceReactNative) - iOS's stocks app clone written in React Native for demo purpose.
 * [Quirk 🐙 ★965](https://github.com/flaque/quirk) - Cognitive Behavioral Therapy for iOS and Android.
-* [TaskRabbit's Sample App ★802](https://github.com/taskrabbit/ReactNativeSampleApp) - a testing ground for Task Rabbit's app making
-* [React Weather ★702](https://github.com/stage88/react-weather) - A simple weather app built with React Native
+* [TaskRabbit's Sample App ★802](https://github.com/taskrabbit/ReactNativeSampleApp) - a testing ground for Task Rabbit's app making.
+* [Manyverse ★758](https://github.com/staltz/manyverse) – Social network off the grid (a Scuttlebutt Android client).
+* [React Weather ★702](https://github.com/stage88/react-weather) - A simple weather app built with React Native.
 * [Boostnote ★630](https://github.com/BoostIO/boostnote-mobile) - Boostnote: open source note taking.
-* [react-native-sudoku ★540](https://github.com/nihgwu/react-native-sudoku) - a sudoku game written in React Native
-* [react-native-hiapp ★513](https://github.com/BelinChung/react-native-hiapp) - A simple and Twitter like demo app written in react-native
+* [react-native-sudoku ★540](https://github.com/nihgwu/react-native-sudoku) - a sudoku game written in React Native.
+* [react-native-hiapp ★513](https://github.com/BelinChung/react-native-hiapp) - A simple and Twitter like demo app written in react-native.
 * [React Native Netflix ★489](https://github.com/mariodev12/react-native-netflix) - A Netflix-like app.
 * [what the thing? ★430](https://github.com/vigzmv/what_the_thing) - Point camera at things to learn how to say them in a different language.
 * [react-native-basketball ★425](https://github.com/FaridSafi/react-native-basketball) - a clone of the Facebook Basketball game
@@ -1379,8 +1381,9 @@ Open source React Native apps and other examples.
 * [ReactNativeRedditReader ★345](https://github.com/akveo/react-native-reddit-reader)
 * [Assemblies ★322](https://github.com/buildreactnative/assemblies) - a Meetup clone
 * [DuckDuckGo App (Unofficial) ★273](https://github.com/kiok46/duckduckgo)
-* [Ziliun React Native ★266](https://github.com/sonnylazuardi/ziliun-react-native) - Wordpress based article reader built with react native
-* [Luno ★266](https://github.com/alwx/luno-react-native) - A ClojureScript React Native app demonstration
+* [Ziliun React Native ★266](https://github.com/sonnylazuardi/ziliun-react-native) - Wordpress based article reader built with react native.
+* [Lyrics King ★266](https://github.com/SKempin/Lyrics-King-React-Native) - Minimalist and stylish lyrics search app.
+* [Luno ★266](https://github.com/alwx/luno-react-native) - A ClojureScript React Native app demonstration.
 * [ReactNativeHackerNews ★241](https://github.com/jsdf/ReactNativeHackerNews)
 * [iOS Conference App made with React Native ★234](https://github.com/mikkoj/NortalTechDay)
 * [MagicMirror ★232](https://github.com/ajwhite/MagicMirror)
@@ -1389,9 +1392,12 @@ Open source React Native apps and other examples.
 * [React Native Example, Geo and Location ★216](https://github.com/bgryszko/react-native-example)
 * [uestc-bbs-react-native ★216](https://github.com/just4fun/uestc-bbs-react-native) - An iOS client for <http://bbs.uestc.edu.cn/> written in React Native with Redux
 * [Sh\*\*t! I Smoke ★209](https://github.com/amaurymartiny/shoot-i-smoke) - Know how many cigarettes you smoke based on the pollution of your location.
-* [PxView ★198](https://github.com/alphasp/pxview) - An unofficial Pixiv app client for Android and iOS
-* [BBC News (Unofficial) ★187](https://github.com/joeltrew/BBCNews-React-Native) - a BBC news app
+* [PxView ★198](https://github.com/alphasp/pxview) - An unofficial Pixiv app client for Android and iOS.
+* [Audio Book App ★193](https://github.com/minhtc/sachnoiapp) – Completed Audiobook app with some cool animations.
+* [BBC News (Unofficial) ★187](https://github.com/joeltrew/BBCNews-React-Native) - a BBC news app.
+* [Instagram clone ★182](https://github.com/reindexio/reindex-examples/tree/master/react-native-gallery) - an Instagram clone.
 * [HackerBuzz ★179](https://github.com/RCiesielczuk/HackerBuzz-ReactNative) - a Hacker News reader.
+* [FastBuy ★172](https://github.com/Bruno-Furtado/fastbuy-app) - App to manage the products from a dummy Store (built with React Native and Redux).
 * [Vecihi App ★170](https://github.com/yasintoy/vecihi) – Build your own photo sharing app.
 * [Rocket.Chat ★161](https://github.com/RocketChat/Rocket.Chat.ReactNative) - Open Source Team Communication
 * [HackerWeb ★158](https://github.com/cheeaun/hackerweb-native) - A simply readable Hacker News web app for iOS & Android.
@@ -1420,55 +1426,49 @@ Open source React Native apps and other examples.
 * [Native iOS font list ★60](https://github.com/yayolius/react-native-font-list)
 * [React Native Chromecast App ★56](https://github.com/holoed/ChromeCast_ReactNative)
 * [MoeFM ★54](https://github.com/codeestX/MoeFM) - A light MusicPlayer build with React Native & Redux for both Android and iOS.
-* [iTunesConnect ★53](https://github.com/oney/iTunesConnect) - Unofficial iTunes Connect App
+* [iTunesConnect ★53](https://github.com/oney/iTunesConnect) - Unofficial iTunes Connect App.
 * [Sequent ★52](https://github.com/sobstel/sequent) - short-term memory training game (W/ Redux).
 * [AudienceNetworkReactNative ★50](https://github.com/7kfpun/AudienceNetworkReactNative) - Facebook Audience Network Performance Tool.
-* [rndrawer-implemented-rnrouter ★50](https://github.com/efkan/rndrawer-implemented-rnrouter) - A react-native-drawer implemented example and scaffolding for react-native-router-flux
-* [Magento 2 Mobile App ★47](https://github.com/troublediehard/magento-react-native) - Magento 2.x mobile app built with React Native
-* [iOS app that transcript your voice with IBM Watson Cloud ★41](https://github.com/yrezgui/meowth-ios)
+* [rndrawer-implemented-rnrouter ★50](https://github.com/efkan/rndrawer-implemented-rnrouter) - A react-native-drawer implemented example and scaffolding for react-native-router-flux.
+* [Magento 2 Mobile App ★47](https://github.com/troublediehard/magento-react-native) - Magento 2.x mobile app built with React Native.
+* [Art Museum ★42](https://github.com/pedrobern/react-native-art-museums-app) - Browse through the endless Harvard's Art Museum collection.
+* [iOS app that transcript your voice with IBM Watson Cloud ★41](https://github.com/yrezgui/meowth-ios).
+* [Forex Rates ★38](https://github.com/MicroPyramid/forex-rates-mobile-app) - Foreign exchange rates. currency rate converter. Historical exchange rates. Android and iOS.
 * [Splitcloud ★35](https://github.com/egm0121/splitcloud-app) - Share listening to two songs at the same time from Soundcloud (by splitting right/left channels).
 * [ZudVPN ★32](https://github.com/zudvpn/ZudVPN) - Deploy private VPN on major Cloud Providers with [ZudVPN](https://www.zudvpn.com)
 * [Todo List ★31](https://github.com/rishabhbhatia/react-native-todo) - Todo-List app using SwipeView with ES6 standards for iOS and Android.
 * [Paramap ★30](https://github.com/twist900/paramap) - Accessability map. React-native with Redux and Firebase. iOS and Android.
 * [Confreaks ★29](https://github.com/cabaret/confreaks-react-native)
-* [Vocab React Native ★27](https://github.com/thaiinhk/VocabReactNative) - Thai Vocabulary Learning App
+* [Vocab React Native ★27](https://github.com/thaiinhk/VocabReactNative) - Thai Vocabulary Learning App.
+* [Cat-or-dog ★27](https://github.com/punksta/Cat-or-dog) - Simple game with drag'n'drops and animations.
 * [Premier League ★25](https://github.com/ennioma/react-native-premier-league)
 * [Roxie ★23](https://github.com/venepe/react-native-roxie) - Sound processing and bluetooth hardware control.
 * [Roverz ★21](https://github.com/mongrov/roverz) - A native mobile chat client library for Rocket.Chat on both iOS and Android.
 * [Text Blast ★18](https://github.com/SeshApp/text-blast-react-native) - iOS client for MMS text blasting app with analogous [ionic version](https://github.com/SeshApp/text-blast-ionic) for comparison
 * [NewYorkTimesTopStories ★14](https://github.com/vidyuthd/NYTimesTopStories-React-Native) - Read Topstories of NewYorkTimes using its api written for android in react-native.
 * [Quick-Sample ★14](https://github.com/innFactory/react-native-quick-sample) - A small and simple example app with navigation, data persistence, redux, listview and animation.
-* [iGap Plus ★13](https://github.com/RooyeKhat-Media/iGap-Plus) - iGap+ is a cross-platform messaging application (Currently Android , iOS and Windows UWP) and has been created using all latest modern technologies. iGap+ is designed to easily support additional platforms like web, macOS and linux.
-* [Posters_Galore_Android ★11](https://github.com/marmelab/Posters_Galore_Android) - An experimental Android application using Redux and a REST API
-* [react-native-medium-clap-animation ★11](https://github.com/saketkumar95/react-native-medium-clap-animation) - Medium Clap Animation in React Native
-* [HupuApp ★9](https://github.com/MelonRice/ReactNative-HupuJRS) - A Third-party Hupu App (<http://bbs.hupu.com/>) client implemented using React Native (Android and iOS).
-* [react-native-uber-clone ★9](https://github.com/saketkumar95/react-native-uber-clone) - Uber UI Clone with animations in react native
-* [Commit Strip (Unofficial) ★8](https://github.com/rizalibnu/commit-strip-react-native) - A CommitStrip.com reader built in React Native.
-* [react-native-otello ★6](https://github.com/hiaw/react_native_otello) - a reversi game written in React Native
-* [GitHub Jobs Search App (Unofficial) ★6](https://github.com/rizalibnu/github-jobs-react-native) - A GitHub Jobs Search App built in React Native.
-* [Minimal Quotes ★6](https://github.com/insiderdev/minimal-quotes) - Mobile app that throws you random quotes in a super clean minimal version.
-* [Hello Bemans ★5](https://github.com/rapportyou/HelloBemans) - Health Trainer Connection App (Android Version)
-* [RNV2ex ★5](https://github.com/dyygtfx/RNV2ex) - react-native for v2ex
-* [Renote ★4](https://github.com/mavajee/react-native-note-example) - A simple react-native example app for make notes.
-* [Manyverse](https://github.com/staltz/manyverse) – Social network off the grid (a Scuttlebutt Android client)
-* [Bristol Pound](http://blog.scottlogic.com/2017/11/22/developing-bristol-pound-an-open-source-react-native-app.html) - An app for the Bristol Pound, a UK-based local currency.
-* [React Native Showcase](https://facebook.github.io/react-native/showcase.html)
-* [Instagram clone](https://github.com/reindexio/reindex-examples/tree/master/react-native-gallery) - an Instagram clone
-* [Joplin](https://github.com/laurent22/joplin/tree/master/ReactNativeClient) - A note taking app for desktop, CLI, and mobile (linked here is the mobile app).
-* [Cat-or-dog](https://github.com/punksta/Cat-or-dog) - Simple game with drag'n'drops and animations.
-* [Forex Rates](https://github.com/MicroPyramid/forex-rates-mobile-app) - Foreign exchange rates. currency rate converter. Historical exchange rates. Android and iOS.
-* [Smog Alert App](https://github.com/Bartozzz/smog-alert-app) – provides real-time air pollution data all around the world and shows nearby polluters.
-* [Audio Book App](https://github.com/minhtc/sachnoiapp) – Completed Audiobook app with some cool animations.
-* [FastBuy](https://github.com/Bruno-Furtado/fastbuy-app) - App to manage the products from a dummy Store (built with React Native and Redux).
-* [Hydropuzzle](https://github.com/hydropuzzle/hydropuzzle) - Stylish puzzle adventure game.
-* [Github-Gist](https://github.com/Arjun-sna/react-native-githubgist-client) - React native mobile application for github gist
-* [Lyrics King](https://github.com/SKempin/Lyrics-King-React-Native) - Minimalist and stylish lyrics search app.
-* [TensorFlow.js Starter](https://github.com/t73liu/tfjs-starter) - TensorFlow.js starter app using MobileNet to predict image class. [Blog post](https://t73liu.github.io/posts/experimenting-with-tfjs/) for additional context.
-* [Art Museum](https://github.com/pedrobern/react-native-art-museums-app) - Browse through the endless Harvard's Art Museum collection.
 * [NMF.earth ★14](https://github.com/NotMyFaultEarth/nmf-app) - Calculate, understand and reduce your carbon footprint. Available for Android and iOS, using Expo, Redux Toolkit and Typescript.
+* [iGap Plus ★13](https://github.com/RooyeKhat-Media/iGap-Plus) - iGap+ is a cross-platform messaging application (Currently Android , iOS and Windows UWP) and has been created using all latest modern technologies. iGap+ is designed to easily support additional platforms like web, macOS and linux.
 * [Nyxo ★12](https://github.com/hello-nyxo/nyxo-app) - Sleep tracker and sleep coaching app. Available for Android and iOS.
 * [React Native Typescript examples ★12](https://github.com/robinhuy/react-native-typescript-examples) - Learn React Native by examples.
+* [Posters_Galore_Android ★11](https://github.com/marmelab/Posters_Galore_Android) - An experimental Android application using Redux and a REST API
+* [react-native-medium-clap-animation ★11](https://github.com/saketkumar95/react-native-medium-clap-animation) - Medium Clap Animation in React Native.
+* [Hydropuzzle ★11](https://github.com/hydropuzzle/hydropuzzle) - Stylish puzzle adventure game.
+* [HupuApp ★9](https://github.com/MelonRice/ReactNative-HupuJRS) - A Third-party Hupu App (<http://bbs.hupu.com/>) client implemented using React Native (Android and iOS).
+* [react-native-uber-clone ★9](https://github.com/saketkumar95/react-native-uber-clone) - Uber UI Clone with animations in react native.
+* [Commit Strip (Unofficial) ★8](https://github.com/rizalibnu/commit-strip-react-native) - A CommitStrip.com reader built in React Native.
+* [Smog Alert App ★8](https://github.com/Bartozzz/smog-alert-app) – provides real-time air pollution data all around the world and shows nearby polluters.
+* [TensorFlow.js Starter ★7](https://github.com/t73liu/tfjs-starter) - TensorFlow.js starter app using MobileNet to predict image class. [Blog post](https://t73liu.github.io/posts/experimenting-with-tfjs/) for additional context.
+* [react-native-otello ★6](https://github.com/hiaw/react_native_otello) - a reversi game written in React Native.
+* [GitHub Jobs Search App (Unofficial) ★6](https://github.com/rizalibnu/github-jobs-react-native) - A GitHub Jobs Search App built in React Native.
+* [Minimal Quotes ★6](https://github.com/insiderdev/minimal-quotes) - Mobile app that throws you random quotes in a super clean minimal version.
+* [Github-Gist ★6](https://github.com/Arjun-sna/react-native-githubgist-client) - React native mobile application for github gist.
+* [Hello Bemans ★5](https://github.com/rapportyou/HelloBemans) - Health Trainer Connection App (Android Version).
+* [RNV2ex ★5](https://github.com/dyygtfx/RNV2ex) - react-native for v2ex.
+* [Renote ★4](https://github.com/mavajee/react-native-note-example) - A simple react-native example app for make notes.
 * [Post Card App ★1](https://github.com/adarsh0d/postcardApp) - Create old style post card and share on whatsapp as image. Built with Expo and available for android.
+* [Bristol Pound](http://blog.scottlogic.com/2017/11/22/developing-bristol-pound-an-open-source-react-native-app.html) - An app for the Bristol Pound, a UK-based local currency.
+* [React Native Showcase](https://facebook.github.io/react-native/showcase.html).
 
 
 ## Frameworks


### PR DESCRIPTION
Here are 2 open source apps I added: 
- https://github.com/robinhuy/react-native-expo-examples.
- https://github.com/robinhuy/react-native-typescript-examples.

I add stars to some opensource apps have no star & reorder by stars:
- Artsy - The mobile app for artsy.net. Discover fine Art. The Art world in your Pocket.
- Manyverse – Social network off the grid (a Scuttlebutt Android client)
- Instagram clone - an Instagram clone
- Joplin - A note taking app for desktop, CLI, and mobile (linked here is the mobile app).
- Cat-or-dog - Simple game with drag'n'drops and animations.
- Forex Rates - Foreign exchange rates. currency rate converter. Historical exchange rates. Android and iOS.
- Smog Alert App – provides real-time air pollution data all around the world and shows nearby polluters.
- Audio Book App – Completed Audiobook app with some cool animations.
- FastBuy - App to manage the products from a dummy Store (built with React Native and Redux).
- Hydropuzzle - Stylish puzzle adventure game.
- Github-Gist - React native mobile application for github gist
- Lyrics King - Minimalist and stylish lyrics search app.
- TensorFlow.js Starter - TensorFlow.js starter app using MobileNet to predict image class. Blog post for additional context.
- Art Museum - Browse through the endless Harvard's Art Museum collection.
