### PR TITLE
Add react-i18next to Internationalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,10 +913,10 @@ Components and native modules.
 
 ### Internationalization
 
+* [react-i18next ★7817](https://github.com/i18next/react-i18next) - A powerful internationalization framework for React / React Native which is based on i18next
 * [fbt ★3202](https://github.com/facebookincubator/fbt) - A JavaScript Internationalization Framework
 * [react-native-localize ★603](https://github.com/react-native-community/react-native-localize) - React Native Localize
 * [react-native-globalize ★192](https://github.com/joshswan/react-native-globalize) - Globalization helper for React Native
-
 * [redux-react-native-i18n ★40](https://github.com/derzunov/redux-react-native-i18n) - An i18n solution for React Native apps on Redux
 * [react-native-intl ★37](https://github.com/taggon/react-native-intl) - React Native module shipped native Intl implementation and Translation extension
 * [rn-translate-template ★18](https://github.com/hiaw/rn-translate-template) - I18n template for all iOS and Android supported languages


### PR DESCRIPTION
While it doesn't have react native in its name, it is marketed as an i18n library for React Native.

I've used i18next in a few React projects, was surprised it wasn't on this list yet.

<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->

https://react.i18next.com/

