### PR TITLE
Add rnx-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,7 +1291,7 @@ Useful React Native tooling.
 * [react-hook-hooker](https://github.com/fjcaetano/react-hook-hooker) - A nifty little HOC to add hooks to your React components.
 * [React Native Elements Playground 🚀](https://react-native-elements.js.org/) - Tinker with `react-native-elements` components in the web.
 * [SimpleLocalize CLI](https://github.com/simplelocalize/simplelocalize-cli) - An open source Localization CLI tool for finding i18n keys in project files.
-* [rnx-gen](https://www.npmjs.com/package/rnx-gen) - A [NestJS](https://nestjs.com/)-style opinionated resources generator to generate screens, components, slices, hooks, and redux files with boilerplate code.
+* [rnx-gen](https://www.npmjs.com/package/rnx-gen) - A NestJS-style opinionated resources generator to generate screens, components, slices, hooks, and redux files with boilerplate code.
 
 ## Seeds
 

--- a/README.md
+++ b/README.md
@@ -1291,6 +1291,7 @@ Useful React Native tooling.
 * [react-hook-hooker](https://github.com/fjcaetano/react-hook-hooker) - A nifty little HOC to add hooks to your React components.
 * [React Native Elements Playground 🚀](https://react-native-elements.js.org/) - Tinker with `react-native-elements` components in the web.
 * [SimpleLocalize CLI](https://github.com/simplelocalize/simplelocalize-cli) - An open source Localization CLI tool for finding i18n keys in project files.
+* [rnx-gen](https://www.npmjs.com/package/rnx-gen) - A [NestJS](https://nestjs.com/)-style opinionated resources generator to generate screens, components, slices, hooks, and redux files with boilerplate code.
 
 ## Seeds
 


### PR DESCRIPTION
Added utility `rnx-gen`: an opinionated, NestJS-style CLI tool to generate resources (screens, components, hooks, slices, etc.) with boilerplate code.

Link: https://www.npmjs.com/package/rnx-gen

Example:
`npx rnx-gen g screen userProfile` will generate a folder `UserProfileScreen` under `src/screens` along with the associated files for the screen (test, constants, styles, types, index).
<img width="538" alt="rnx-gen-example-screen" src="https://github.com/user-attachments/assets/e9e67821-80ee-439c-8033-1f852f701f61">





