### PR TITLE
Add react-native-remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ Components and native modules.
 * [react-native-htmltext ★132](https://github.com/siuying/react-native-htmltext) - Use HTML like markup to create stylized text in react-native.
 * [react-native-html-webview ★102](https://github.com/almost/react-native-html-webview) - Display (possibly untrusted) HTML using a UIWebView in React Native.
 * [react-native-html-render ★98](https://github.com/soliury/react-native-html-render) - A html render for react-native
+* [react-native-remark](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
 * [react-native-markdown-display ★57](https://github.com/iamacup/react-native-markdown-display/) - Highly customizable Markdown renderer using native components for all its elements without any web-view.
 * [react-native-measure-text ★48](https://github.com/airamrguez/react-native-measure-text) - Measure text height without laying it out.
 * [react-native-markdown-editor ★47](https://github.com/kunall17/react-native-markdown-editor) - Markdown editor like github comment editor (contains preview, markdown buttons)

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ Components and native modules.
 * [react-native-htmltext ★132](https://github.com/siuying/react-native-htmltext) - Use HTML like markup to create stylized text in react-native.
 * [react-native-html-webview ★102](https://github.com/almost/react-native-html-webview) - Display (possibly untrusted) HTML using a UIWebView in React Native.
 * [react-native-html-render ★98](https://github.com/soliury/react-native-html-render) - A html render for react-native
-* [react-native-remark](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
+* [react-native-remark ★6](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
 * [react-native-markdown-display ★57](https://github.com/iamacup/react-native-markdown-display/) - Highly customizable Markdown renderer using native components for all its elements without any web-view.
 * [react-native-measure-text ★48](https://github.com/airamrguez/react-native-measure-text) - Measure text height without laying it out.
 * [react-native-markdown-editor ★47](https://github.com/kunall17/react-native-markdown-editor) - Markdown editor like github comment editor (contains preview, markdown buttons)

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ Components and native modules.
 * [react-native-htmltext ★132](https://github.com/siuying/react-native-htmltext) - Use HTML like markup to create stylized text in react-native.
 * [react-native-html-webview ★102](https://github.com/almost/react-native-html-webview) - Display (possibly untrusted) HTML using a UIWebView in React Native.
 * [react-native-html-render ★98](https://github.com/soliury/react-native-html-render) - A html render for react-native
-* [react-native-remark ★6](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
+* [react-native-remark ★9](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
 * [react-native-markdown-display ★57](https://github.com/iamacup/react-native-markdown-display/) - Highly customizable Markdown renderer using native components for all its elements without any web-view.
 * [react-native-measure-text ★48](https://github.com/airamrguez/react-native-measure-text) - Measure text height without laying it out.
 * [react-native-markdown-editor ★47](https://github.com/kunall17/react-native-markdown-editor) - Markdown editor like github comment editor (contains preview, markdown buttons)

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ Components and native modules.
 * [react-native-htmltext ★132](https://github.com/siuying/react-native-htmltext) - Use HTML like markup to create stylized text in react-native.
 * [react-native-html-webview ★102](https://github.com/almost/react-native-html-webview) - Display (possibly untrusted) HTML using a UIWebView in React Native.
 * [react-native-html-render ★98](https://github.com/soliury/react-native-html-render) - A html render for react-native
-* [react-native-remark ★9](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
+* [react-native-remark ★21](https://github.com/imwithye/react-native-remark) - A beautiful and customizable Markdown renderer for React Native that supports GFM, syntax highlighting, tables, images, dark mode, and more (without webview).
 * [react-native-markdown-display ★57](https://github.com/iamacup/react-native-markdown-display/) - Highly customizable Markdown renderer using native components for all its elements without any web-view.
 * [react-native-measure-text ★48](https://github.com/airamrguez/react-native-measure-text) - Measure text height without laying it out.
 * [react-native-markdown-editor ★47](https://github.com/kunall17/react-native-markdown-editor) - Markdown editor like github comment editor (contains preview, markdown buttons)


### PR DESCRIPTION
I tried various Markdown rendering solutions in React Native but couldn’t find one that looked elegant or felt flexible enough. So I built `react-native-remark`.

react-native-remark:

•	Built on top of the `unified` and `remark` ecosystems
•	Supports GitHub Flavored Markdown (GFM), including tables, code blocks, images, and lists
•	Includes syntax highlighting for code blocks with dark mode support
•	Provides horizontal scroll for tables to improve readability on mobile
•	Enables custom renderers and styles for full UI customization
•	Exposes callbacks for handling link presses and code copy actions
•	Designed for elegant, native-feeling Markdown rendering in React Native apps