### PR TITLE
Add hugeicons icon library to UI  components

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ Components and native modules.
 ### UI
 
 * [lottie-react-native ★10415](https://github.com/airbnb/lottie-react-native) - A mobile library for Android and iOS that parses Adobe After Effects animations exported as JSON with bodymovin and renders them natively on mobile!
-* [react-icomoon](https://github.com/aykutkardas/react-icomoon) - With React-Icomoon you can easily use the icons you have selected or created in icomoon. 📦 Zero Dependencies and Lightweight. 
+* [react-icomoon](https://github.com/aykutkardas/react-icomoon) - With React-Icomoon you can easily use the icons you have selected or created in icomoon. 📦 Zero Dependencies and Lightweight.
+* [hugeicons](https://github.com/hugeicons/react-native) - Beautiful, production-ready icon package for React Native.
 * [react-native-vector-icons ★9985](https://github.com/oblador/react-native-vector-icons) - Customizable Icons for React Native with support for NavBar/TabBar, image source and full styling. Choose from 3000+ bundled icons or use your own.
 * [react-native-maps ★8388](https://github.com/lelandrichardson/react-native-maps) - React Native Map components for iOS + Android
 * [react-native-swiper ★6955](https://github.com/leecade/react-native-swiper) - The best Swiper component for React Native.


### PR DESCRIPTION
### Add hugeicons icon library to UI components 
                                              
  Added hugeicons to the UI components section. Hugeicons is a production-ready icon package for React Native.
                                              
  - Repository:                               
  https://github.com/hugeicons/react-native   
  - Installation: `npm i @hugeicons/react-native @hugeicons/core-free-icons` 
