### PR TITLE
Add Mobile App Wiki to Reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Content published on the Web.
 ### Reference
 
 * [React Native Styling Cheatsheet ★2679](https://github.com/vhpoet/react-native-styling-cheat-sheet)
+* [Mobile App Wiki](https://mobileapp.wiki) - Free encyclopedia for mobile app development covering ASO, monetization, store policies, metrics, UI/UX, testing, and infrastructure.
 
 ### Howtos
 


### PR DESCRIPTION
<!--
Added [Mobile App Wiki](https://mobileapp.wiki) to the Articles > Reference section.

A free encyclopedia for mobile app development covering ASO, monetization, store policies, metrics, UI/UX, testing, and infrastructure. 284 articles, no paywall, no account required.
-->


