### PR TITLE
chore: add react-native-super-calendar to the ui section

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ Components and native modules.
 * [react-native-select-multiple  ★58](https://github.com/tableflip/react-native-select-multiple) -A simple and easy to use component for multiple selection of item from List.
 * [react-native-easy-content-loader ★57](https://github.com/sarmad1995/react-native-easy-content-loader) - React-Native light weight skeleton content loading.
 * [react-native-multiple-choice ★57](https://github.com/d-a-n/react-native-multiple-choice) - A cross-platform (iOS / Android) single and multiple-choice React Native component.
+* [react-native-super-calendar](https://github.com/afonsojramos/react-native-super-calendar) - Virtualized month/week/day calendar and date picker with a pinch-to-zoom time grid. iOS, Android, and web.
 * [k-react-native-swipe-unlocker ★55](https://github.com/leowang721/k-react-native-swipe-unlocker) - A simple swipe unlock for React Native
 * [react-native-walkthrough-tooltip ★55](https://github.com/CompanyCam/react-native-walkthrough-tooltip) - Highlight a component via tooltip/popover
 * [react-native-adbannerview ★52](https://github.com/Purii/react-native-adbannerview) - React Native Bridge for ADBannerView

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ Components and native modules.
 * [react-native-select-multiple  ★58](https://github.com/tableflip/react-native-select-multiple) -A simple and easy to use component for multiple selection of item from List.
 * [react-native-easy-content-loader ★57](https://github.com/sarmad1995/react-native-easy-content-loader) - React-Native light weight skeleton content loading.
 * [react-native-multiple-choice ★57](https://github.com/d-a-n/react-native-multiple-choice) - A cross-platform (iOS / Android) single and multiple-choice React Native component.
-* [react-native-super-calendar](https://github.com/afonsojramos/react-native-super-calendar) - Virtualized month/week/day calendar and date picker with a pinch-to-zoom time grid. iOS, Android, and web.
+* [react-native-super-calendar ★55](https://github.com/afonsojramos/react-native-super-calendar) - Virtualized month/week/day calendar and date picker with a pinch-to-zoom time grid. iOS, Android, and web.
 * [k-react-native-swipe-unlocker ★55](https://github.com/leowang721/k-react-native-swipe-unlocker) - A simple swipe unlock for React Native
 * [react-native-walkthrough-tooltip ★55](https://github.com/CompanyCam/react-native-walkthrough-tooltip) - Highlight a component via tooltip/popover
 * [react-native-adbannerview ★52](https://github.com/Purii/react-native-adbannerview) - React Native Bridge for ADBannerView


### PR DESCRIPTION
<!--
Please also add a link to what you just added here.
Thank you.

Anywhere under here is perfect!
-->


react-native-super-calendar is a collection of month/week/day/schedule views plus a date picker, virtualized (Legend List) with a pinch-to-zoom time grid that runs on the UI thread. Works on iOS, Android, and web.

Browser demo: https://afonsojramos.github.io/react-native-super-calendar/
Repo: https://github.com/afonsojramos/react-native-super-calendar
Docs: https://super-calendar.afonsojramos.me/