### PR TITLE
Add react-native-liquid-glassmorphism

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Components and native modules.
 * [react-native-paper ★2218](https://github.com/callstack/react-native-paper) - Material design for React Native
 * [react-native-swipeout ★2194](https://github.com/dancormier/react-native-swipeout) - iOS-style swipeout buttons behind component
 * [react-native-blur ★2172](https://github.com/Kureev/react-native-blur) - React Native Blur component
-* [react-native-liquid-glassmorphism](https://github.com/himanshu-lal4/react-native-liquid-glassmorphism) - Authentic Liquid Glass on iOS and Android from one component: native UIGlassEffect on iOS 26, a real-time AGSL refraction shader on Android, custom shapes, interactive touch/tilt, Expo config plugin, TypeScript.
+* [react-native-liquid-glassmorphism](https://github.com/himanshu-lal4/react-native-liquid-glassmorphism) - Liquid Glass for iOS and Android - native UIGlassEffect on iOS 26, an AGSL refraction shader on Android, and glass views that merge into one liquid body on contact.
 * [react-native-progress ★2069](https://github.com/oblador/react-native-progress) - Progress indicators and spinners for React Native using ReactART.
 * [react-native-textinput-effects ★2062](https://github.com/halilb/react-native-textinput-effects) - Text inputs with custom label and icon animations for iOS and Android. Built by react native and inspired by Codrops.
 * [react-native-modalbox ★2043](https://github.com/maxs15/react-native-modalbox) - A component for react-native

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Components and native modules.
 * [react-native-paper ★2218](https://github.com/callstack/react-native-paper) - Material design for React Native
 * [react-native-swipeout ★2194](https://github.com/dancormier/react-native-swipeout) - iOS-style swipeout buttons behind component
 * [react-native-blur ★2172](https://github.com/Kureev/react-native-blur) - React Native Blur component
+* [react-native-liquid-glassmorphism](https://github.com/himanshu-lal4/react-native-liquid-glassmorphism) - Authentic Liquid Glass on iOS and Android from one component: native UIGlassEffect on iOS 26, a real-time AGSL refraction shader on Android, custom shapes, interactive touch/tilt, Expo config plugin, TypeScript.
 * [react-native-progress ★2069](https://github.com/oblador/react-native-progress) - Progress indicators and spinners for React Native using ReactART.
 * [react-native-textinput-effects ★2062](https://github.com/halilb/react-native-textinput-effects) - Text inputs with custom label and icon animations for iOS and Android. Built by react native and inspired by Codrops.
 * [react-native-modalbox ★2043](https://github.com/maxs15/react-native-modalbox) - A component for react-native


### PR DESCRIPTION
Adds [react-native-liquid-glassmorphism](https://github.com/himanshu-lal4/react-native-liquid-glassmorphism) to **Components → UI**.

Liquid Glass for React Native on **both iOS and Android**:

- **iOS 26** — Apple's native `UIGlassEffect`, with a `UIBlurEffect` fallback below 26
- **Android** — a real-time AGSL refractive-lens shader (edge refraction, chromatic dispersion, mirrored edge reflection, Fresnel rim), with blur and tint fallbacks below API 33
- **Merging** — glass views fuse into one liquid body when they come close, on both platforms. iOS uses `UIGlassContainerEffect`; Android has no OS equivalent, so the shapes are smooth-min blended per pixel in the shader
- Custom shapes from any SVG path, progressive scroll-edge blur, and Reduce Transparency / Reduce Motion support
- MIT, TypeScript, Expo config plugin, New Architecture and old architecture, zero runtime dependencies

**Placement:** directly after `react-native-blur`, grouping it with the other blur/glass entries. The section is broadly ordered by star count but not strictly — `react-native-blurhash ★105` already sits among the 2200s — so I favoured topical adjacency. Happy to move it to the end of the section if you'd prefer strict ordering.

Checked against the contribution guidelines: single suggestion, `[PACKAGE](LINK) - DESCRIPTION.` format with a trailing period, no trailing whitespace, and searched the list first to confirm it isn't already present.

<sub>Updated from the original July submission: the library has shipped since, and the description now leads with cross-platform merging rather than Android glass optics — several other libraries ship AGSL on Android now, so that was no longer a distinguishing claim.</sub>