### PR TITLE
chore: add Super Calendar to the UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Tools for building React Native apps with AI agents, and for putting AI inside y
 - [react-native-blur](https://github.com/margelo/react-native-blur) - Native blur view component.
 - [react-native-blurhash](https://github.com/mrousavy/react-native-blurhash) - Colorful blurry placeholders while content loads.
 - [react-native-calendars](https://github.com/wix/react-native-calendars) - Feature-rich calendar components.
+- [Super Calendar](https://github.com/afonsojramos/super-calendar) - Gesture-driven, virtualized month, week, day, and schedule views plus a date picker, for React Native and web.
 - [react-native-date-picker](https://github.com/henninghall/react-native-date-picker) - Native date and time picker for Android and iOS.
 - [react-native-reanimated-carousel](https://github.com/dohooo/react-native-reanimated-carousel) - Swiper/carousel built entirely on Reanimated, the successor to snap-carousel.
 - [react-native-pager-view](https://github.com/callstack/react-native-pager-view) - Native ViewPager and UIPageViewController wrapper.


### PR DESCRIPTION
Resubmitting against the new README after the overhaul (previous PR: #1212). The demo link in that one is dead, the repo has since been renamed.

Super Calendar is a render-agnostic calendar for React Native and the web. It ships month, week, day, 3-day, custom, schedule, and year views plus a standalone date picker, virtualized with Legend List, and the pinch-to-zoom time grid and drag-to-create gestures run on the UI thread in Reanimated worklets.

- Repo: https://github.com/afonsojramos/super-calendar
- Docs: https://super-calendar.afonsojramos.me/
- Live demo: https://afonsojramos.github.io/super-calendar/

Against the new criteria:

- **Actively maintained**: v2.9.0 released 2026-08-24, with releases every few weeks.
- **Current React Native**: New Architecture only, built on Reanimated v4 and react-native-worklets.
- **Adoption**: ~7k monthly npm downloads for `@super-calendar/native`, 187 stars.

Disclosure: I am the author.
