### PR TITLE
Add Hugeicons to Components > UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Tools for building React Native apps with AI agents, and for putting AI inside y
 - [NativeBase](https://github.com/GeekyAnts/NativeBase) - Mobile-first, accessible component library for React Native and web.
 - [Shoutem UI](https://github.com/shoutem/ui) - Customizable set of styled components for React Native.
 - [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) - Customizable icon sets with support for styling and image sources.
+- [Hugeicons](https://github.com/hugeicons/hugeicons) - Pixel-perfect icon library with 5,400+ free icons as tree-shakeable React Native components, rendered with react-native-svg.
 - [lottie-react-native](https://github.com/lottie-react-native/lottie-react-native) - Render After Effects animations natively.
 - [react-native-svg](https://github.com/software-mansion/react-native-svg) - SVG rendering for React Native and web.
 - [react-native-svg-transformer](https://github.com/kristerkari/react-native-svg-transformer) - Import SVG files as components, like on the web.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Tools for building React Native apps with AI agents, and for putting AI inside y
 - [NativeBase](https://github.com/GeekyAnts/NativeBase) - Mobile-first, accessible component library for React Native and web.
 - [Shoutem UI](https://github.com/shoutem/ui) - Customizable set of styled components for React Native.
 - [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) - Customizable icon sets with support for styling and image sources.
-- [Hugeicons](https://github.com/hugeicons/hugeicons) - Pixel-perfect icon library with 5,400+ free icons as tree-shakeable React Native components, rendered with react-native-svg.
+- [Hugeicons](https://github.com/hugeicons/hugeicons) - Pixel-perfect icon library with 6,000+ free icons as tree-shakeable React Native components, rendered with react-native-svg.
 - [lottie-react-native](https://github.com/lottie-react-native/lottie-react-native) - Render After Effects animations natively.
 - [react-native-svg](https://github.com/software-mansion/react-native-svg) - SVG rendering for React Native and web.
 - [react-native-svg-transformer](https://github.com/kristerkari/react-native-svg-transformer) - Import SVG files as components, like on the web.


### PR DESCRIPTION
Resubmission of #1160 against the rebuilt README, per the housekeeping note there (that PR can no longer be reopened, so this is a fresh one). Branched off current `master`; the diff is a single line.

Adds **Hugeicons** to **Components → UI**, next to the other icon and SVG entries:

```
- [Hugeicons](https://github.com/hugeicons/hugeicons) - Pixel-perfect icon library with 6,000+ free icons as tree-shakeable React Native components, rendered with react-native-svg.
```

### What it is

An open-source icon library shipped as first-class React Native components. Icons are imported individually from a separate icon package, so only what you use is bundled.

```sh
npm i @hugeicons/react-native @hugeicons/core-free-icons
```

```jsx
import { HugeiconsIcon } from '@hugeicons/react-native';
import { Home01Icon } from '@hugeicons/core-free-icons';

<HugeiconsIcon icon={Home01Icon} size={24} color="#111" strokeWidth={1.5} />
```

- Monorepo: https://github.com/hugeicons/hugeicons
- React Native package: https://github.com/hugeicons/hugeicons/tree/main/packages/react-native
- Browse icons: https://hugeicons.com/icons

### Against the new curation criteria

- **Actively maintained** — `@hugeicons/react-native` v1.0.16 published this month; the monorepo is under active development.
- **Current React Native** — peer deps are `react-native >= 0.60` and `react-native-svg >= 12`; works on the New Architecture, since rendering goes through react-native-svg rather than any custom native module. No native code of its own, so no linking step.
- **Adoption** — 1.2k+ stars on the repo, and the icon packages are widely used across the web ecosystem; this is the React Native surface of that same set.
- **Disclosure** — I work on Hugeicons, so this is a self-submission.
- Free tier is MIT-licensed (6,000+ icons); a paid tier covers the full 60,000+ set.

Not a duplicate of `react-native-vector-icons` — that wraps icon fonts, this ships SVG components with per-icon imports and adjustable stroke width.
